### PR TITLE
WIP: Continuous deployment and delivery versioning mode

### DIFF
--- a/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -64,6 +64,7 @@ branches:
         var config = ConfigurationProvider.Provide(gitDirectory, fileSystem);
         config.Branches["develop"].VersioningMode.ShouldBe(VersioningMode.ContinuousDeployment);
         config.Release.VersioningMode.ShouldBe(VersioningMode.ContinuousDelivery);
+        config.Develop.Tag.ShouldBe("unstable");
     }
 
     [Test]

--- a/GitVersionCore.Tests/ConfigProviderTests.cs
+++ b/GitVersionCore.Tests/ConfigProviderTests.cs
@@ -30,6 +30,13 @@ develop-branch-tag: alpha
 release-branch-tag: rc
 next-version: 2.0.0
 tag-prefix: '[vV|version-]'
+mode: ContinuousDelivery
+develop:
+    mode: ContinuousDeployment
+    tag: dev
+release*:
+   mode: ContinuousDeployment
+   tag: rc 
 ";
         SetupConfigFileContent(text);
 
@@ -39,6 +46,25 @@ tag-prefix: '[vV|version-]'
         config.ReleaseBranchTag.ShouldBe("rc");
         config.NextVersion.ShouldBe("2.0.0");
         config.TagPrefix.ShouldBe("[vV|version-]");
+        config.Release.VersioningMode.ShouldBe(VersioningMode.ContinuousDeployment);
+        config.Develop.VersioningMode.ShouldBe(VersioningMode.ContinuousDeployment);
+        config.VersioningMode.ShouldBe(VersioningMode.ContinuousDelivery);
+        config.Release.Tag.ShouldBe("rc");
+        config.Develop.Tag.ShouldBe("dev");
+    }
+
+    [Test]
+    public void CanInheritVersioningMode()
+    {
+        const string text = @"
+mode: ContinuousDelivery
+develop:
+    mode: ContinuousDeployment
+";
+        SetupConfigFileContent(text);
+        var config = ConfigurationProvider.Provide(gitDirectory, fileSystem);
+        config.Develop.VersioningMode.ShouldBe(VersioningMode.ContinuousDeployment); 
+        config.Release.VersioningMode.ShouldBe(VersioningMode.ContinuousDelivery);
     }
 
     [Test]

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/DevelopScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/DevelopScenarios.cs
@@ -35,12 +35,9 @@ public class DevelopScenarios
     [Test]
     public void CanChangeDevelopTagViaConfig()
     {
-        using (var fixture = new EmptyRepositoryFixture(new Config
-        {
-            Develop = {
-                       Tag = "alpha"
-            }
-        }))
+        var config = new Config();
+        config.Branches["develop"].Tag = "alpha";
+        using (var fixture = new EmptyRepositoryFixture(config))
         {
             fixture.Repository.MakeATaggedCommit("1.0.0");
             fixture.Repository.CreateBranch("develop").Checkout();
@@ -51,13 +48,9 @@ public class DevelopScenarios
     [Test]
     public void CanHandleContinuousDelivery()
     {
-        using (var fixture = new EmptyRepositoryFixture(new Config
-        {
-            Develop =
-            {
-                VersioningMode = VersioningMode.ContinuousDelivery
-            }
-        }))
+        var config = new Config();
+        config.Branches["develop"].VersioningMode = VersioningMode.ContinuousDelivery;
+        using (var fixture = new EmptyRepositoryFixture(config))
         {
             fixture.Repository.MakeATaggedCommit("1.0.0");
             fixture.Repository.CreateBranch("develop").Checkout();

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/DevelopScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/DevelopScenarios.cs
@@ -37,12 +37,32 @@ public class DevelopScenarios
     {
         using (var fixture = new EmptyRepositoryFixture(new Config
         {
-            DevelopBranchTag = "alpha"
+            Develop = {
+                       Tag = "alpha"
+            }
         }))
         {
             fixture.Repository.MakeATaggedCommit("1.0.0");
             fixture.Repository.CreateBranch("develop").Checkout();
             fixture.AssertFullSemver("1.1.0-alpha.0+0");
+        }
+    }
+
+    [Test]
+    public void CanHandleContinuousDelivery()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config
+        {
+            Develop =
+            {
+                VersioningMode = VersioningMode.ContinuousDelivery
+            }
+        }))
+        {
+            fixture.Repository.MakeATaggedCommit("1.0.0");
+            fixture.Repository.CreateBranch("develop").Checkout();
+            fixture.Repository.MakeATaggedCommit("1.1.0-alpha7");
+            fixture.AssertFullSemver("1.1.0-alpha.7+1");
         }
     }
     
@@ -51,7 +71,7 @@ public class DevelopScenarios
     {
         using (var fixture = new EmptyRepositoryFixture(new Config
         {
-            DevelopBranchTag = ""
+            Develop = {Tag= ""}
         }))
         {
             fixture.Repository.MakeATaggedCommit("1.0.0");

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/ReleaseBranchTests.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/ReleaseBranchTests.cs
@@ -36,6 +36,25 @@ public class GitFlowReleaseBranchTests
     }
 
     [Test]
+    public void CanHandleContinuousDeployment()
+    {
+        var config = new Config
+                         {
+                             VersioningMode = VersioningMode.ContinuousDeployment
+                         };
+        using (var fixture = new EmptyRepositoryFixture(config))
+        {
+            fixture.Repository.MakeATaggedCommit("1.0.3");
+            fixture.Repository.CreateBranch("develop");
+            fixture.Repository.MakeCommits(5);
+            fixture.Repository.CreateBranch("release-2.0.0");
+            fixture.Repository.Checkout("release-2.0.0");
+
+            fixture.AssertFullSemver("2.0.0-beta.5+5");
+        }
+    }
+
+    [Test]
     public void CanHandleReleaseBranchWithStability()
     {
         using (var fixture = new EmptyRepositoryFixture(new Config()))

--- a/GitVersionCore/Configuration/BranchConfig.cs
+++ b/GitVersionCore/Configuration/BranchConfig.cs
@@ -1,0 +1,13 @@
+﻿namespace GitVersion
+{
+    using YamlDotNet.Serialization;
+
+    public class BranchConfig
+    {
+        [YamlAlias("mode")]
+        public VersioningMode VersioningMode { get; set; }
+
+        [YamlAlias("tag")]
+        public string Tag { get; set; }
+    }
+}

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -4,12 +4,17 @@
 
     public class Config
     {
+        VersioningMode versioningMode;
+
         public Config()
         {
             AssemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch;
             DevelopBranchTag = "unstable";
             ReleaseBranchTag = "beta";
             TagPrefix = "[vV]";
+            Release = new BranchConfig();
+            Develop = new BranchConfig();
+            VersioningMode = VersioningMode.ContinuousDelivery;
         }
 
         [YamlAlias("assembly-versioning-scheme")]
@@ -20,6 +25,28 @@
 
         [YamlAlias("release-branch-tag")]
         public string ReleaseBranchTag { get; set; }
+
+        [YamlAlias("mode")]
+        public VersioningMode VersioningMode
+        {
+            get
+            {
+                return this.versioningMode;
+            }
+            set
+            {
+                Develop.VersioningMode = value;
+                Release.VersioningMode = value;
+                this.versioningMode = value;
+            }
+        }
+
+        [YamlAlias("develop")]
+        public BranchConfig Develop { get; set; }
+
+        [YamlAlias("release*")]
+        public BranchConfig Release { get; set; }
+
 
         [YamlAlias("tag-prefix")]
         public string TagPrefix { get; set; }

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -1,5 +1,7 @@
 ﻿namespace GitVersion
 {
+    using System;
+
     using YamlDotNet.Serialization;
 
     public class Config
@@ -9,22 +11,43 @@
         public Config()
         {
             AssemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch;
-            DevelopBranchTag = "unstable";
-            ReleaseBranchTag = "beta";
             TagPrefix = "[vV]";
-            Release = new BranchConfig();
-            Develop = new BranchConfig();
+            Release = new BranchConfig { Tag = "beta" };
+            Develop = new BranchConfig { Tag = "unstable" };
             VersioningMode = VersioningMode.ContinuousDelivery;
+            Develop.VersioningMode = VersioningMode.ContinuousDeployment;
         }
 
         [YamlAlias("assembly-versioning-scheme")]
         public AssemblyVersioningScheme AssemblyVersioningScheme { get; set; }
 
         [YamlAlias("develop-branch-tag")]
-        public string DevelopBranchTag { get; set; }
+        [Obsolete]
+        public string DevelopBranchTag
+        {
+            set
+            {
+                Develop.Tag = value;
+            }
+            get
+            {
+                return Develop.Tag;
+            }
+        }
 
         [YamlAlias("release-branch-tag")]
-        public string ReleaseBranchTag { get; set; }
+        [Obsolete]
+        public string ReleaseBranchTag 
+        {
+            set
+            {
+                Release.Tag = value;
+            }
+            get
+            {
+                return Release.Tag;
+            }
+        }
 
         [YamlAlias("mode")]
         public VersioningMode VersioningMode

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -76,8 +76,19 @@
             }
             set
             {
-                value.ToList().ForEach(_ => branches[_.Key] = _.Value);
+                value.ToList().ForEach(_ => branches[_.Key] = MergeObjects(branches[_.Key],  _.Value));
             }
+        }
+
+        private T MergeObjects<T>(T target, T source)
+        {
+            typeof(T).GetProperties()
+                .Where(prop => prop.CanRead && prop.CanWrite)
+                .Select(_ => new {prop = _, value =_.GetValue(source, null) } )
+                .Where(_ => _.value != null)
+                .ToList()
+                .ForEach(_ => _.prop.SetValue(target, _.value, null));
+            return target;
         }
 
         [YamlAlias("tag-prefix")]

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -54,13 +54,13 @@
         {
             get
             {
-                return this.versioningMode;
+                return versioningMode;
             }
             set
             {
                 Develop.VersioningMode = value;
                 Release.VersioningMode = value;
-                this.versioningMode = value;
+                versioningMode = value;
             }
         }
 

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -1,6 +1,8 @@
 ﻿namespace GitVersion
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     using YamlDotNet.Serialization;
 
@@ -8,12 +10,14 @@
     {
         VersioningMode versioningMode;
 
+        Dictionary<string, BranchConfig> branches = new Dictionary<string, BranchConfig>();
+
         public Config()
         {
             AssemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch;
             TagPrefix = "[vV]";
-            Release = new BranchConfig { Tag = "beta" };
-            Develop = new BranchConfig { Tag = "unstable" };
+            Branches["release[/-]"] = new BranchConfig { Tag = "beta" };
+            Branches["develop"] = new BranchConfig { Tag = "unstable" };
             VersioningMode = VersioningMode.ContinuousDelivery;
             Develop.VersioningMode = VersioningMode.ContinuousDeployment;
         }
@@ -58,23 +62,46 @@
             }
             set
             {
-                Develop.VersioningMode = value;
-                Release.VersioningMode = value;
+                Branches.ToList().ForEach(b => b.Value.VersioningMode = value);
                 versioningMode = value;
             }
         }
 
-        [YamlAlias("develop")]
-        public BranchConfig Develop { get; set; }
-
-        [YamlAlias("release*")]
-        public BranchConfig Release { get; set; }
-
+        [YamlAlias("branches")]
+        public Dictionary<string, BranchConfig> Branches
+        {
+            get
+            {
+                return branches;
+            }
+            set
+            {
+                value.ToList().ForEach(_ => branches[_.Key] = _.Value);
+            }
+        }
 
         [YamlAlias("tag-prefix")]
         public string TagPrefix { get; set; }
 
         [YamlAlias("next-version")]
         public string NextVersion { get; set; }
+
+        [Obsolete]
+        public BranchConfig Develop
+        {
+            get
+            {
+                return Branches["develop"];
+            }
+        }
+
+        [Obsolete]
+        public BranchConfig Release
+        {
+            get
+            {
+                return Branches["release[/-]"];
+            }
+        }
     }
 }

--- a/GitVersionCore/Configuration/ConfigReader.cs
+++ b/GitVersionCore/Configuration/ConfigReader.cs
@@ -20,10 +20,11 @@
         public static void WriteSample(TextWriter writer)
         {
             writer.WriteLine("# assembly-versioning-scheme: MajorMinorPatchMetadata | MajorMinorPatch | MajorMinor | Major");
-            writer.WriteLine("# develop-branch-tag: alpha");
-            writer.WriteLine("# release-branch-tag: rc");
             writer.WriteLine("# tag-prefix: '[vV|version-] # regex to match git tag prefix");
             writer.WriteLine("# next-version: 1.0.0");
+            writer.WriteLine("# mode: ContinuousDelivery | ContinuousDeployment");
+            writer.WriteLine("# release*:\n    mode: ContinuousDelivery | ContinuousDeployment\n    tag: rc");
+            writer.WriteLine("# develop:\n    mode: ContinuousDelivery | ContinuousDeployment\n    tag: alpha");
         }
     }
 }

--- a/GitVersionCore/Configuration/ConfigReader.cs
+++ b/GitVersionCore/Configuration/ConfigReader.cs
@@ -23,8 +23,9 @@
             writer.WriteLine("# tag-prefix: '[vV|version-] # regex to match git tag prefix");
             writer.WriteLine("# next-version: 1.0.0");
             writer.WriteLine("# mode: ContinuousDelivery | ContinuousDeployment");
-            writer.WriteLine("# release*:\n    mode: ContinuousDelivery | ContinuousDeployment\n    tag: rc");
-            writer.WriteLine("# develop:\n    mode: ContinuousDelivery | ContinuousDeployment\n    tag: alpha");
+            writer.WriteLine("#branches:");
+            writer.WriteLine("#   release[/-]*:\n    mode: ContinuousDelivery | ContinuousDeployment\n    tag: rc");
+            writer.WriteLine("#   develop:\n    mode: ContinuousDelivery | ContinuousDeployment\n    tag: alpha");
         }
     }
 }

--- a/GitVersionCore/GitFlow/BranchFinders/DevelopBasedVersionFinderBase.cs
+++ b/GitVersionCore/GitFlow/BranchFinders/DevelopBasedVersionFinderBase.cs
@@ -9,7 +9,7 @@ namespace GitVersion
             GitVersionContext context,
             BranchType branchType)
         {
-            context.CurrentBranchConfig = context.Configuration.Develop;
+            context.CurrentBranchConfig = context.Configuration.Branches["develop"];
             var ancestor = FindCommonAncestorWithDevelop(context.Repository, context.CurrentBranch, branchType);
 
             if (!IsThereAnyCommitOnTheBranch(context.Repository, context.CurrentBranch))

--- a/GitVersionCore/GitFlow/BranchFinders/DevelopBasedVersionFinderBase.cs
+++ b/GitVersionCore/GitFlow/BranchFinders/DevelopBasedVersionFinderBase.cs
@@ -9,6 +9,7 @@ namespace GitVersion
             GitVersionContext context,
             BranchType branchType)
         {
+            context.CurrentBranchConfig = context.Configuration.Develop;
             var ancestor = FindCommonAncestorWithDevelop(context.Repository, context.CurrentBranch, branchType);
 
             if (!IsThereAnyCommitOnTheBranch(context.Repository, context.CurrentBranch))

--- a/GitVersionCore/GitFlow/BranchFinders/DevelopVersionFinder.cs
+++ b/GitVersionCore/GitFlow/BranchFinders/DevelopVersionFinder.cs
@@ -21,7 +21,7 @@ namespace GitVersion
             var c = context.Repository.Commits.QueryBy(f);
             var numberOfCommitsSinceRelease = c.Count();
 
-            var shortVersion = new SemanticVersion()
+            var shortVersion = new SemanticVersion
                                    {
                                        Major = versionFromMaster.Major,
                                        Minor = versionFromMaster.Minor + 1,

--- a/GitVersionCore/GitFlow/BranchFinders/DevelopVersionFinder.cs
+++ b/GitVersionCore/GitFlow/BranchFinders/DevelopVersionFinder.cs
@@ -21,12 +21,23 @@ namespace GitVersion
             var c = context.Repository.Commits.QueryBy(f);
             var numberOfCommitsSinceRelease = c.Count();
 
+            var shortVersion = new SemanticVersion()
+                                   {
+                                       Major = versionFromMaster.Major,
+                                       Minor = versionFromMaster.Minor + 1,
+                                       Patch = 0,
+                                   };
+
+            var applicableTagsInDescendingOrder = context.Repository.SemVerTagsRelatedToVersion(context.Configuration, shortVersion).OrderByDescending(tag => SemanticVersion.Parse(tag.Name, context.Configuration.TagPrefix)).ToList();
+            var preReleaseTag = context.CurrentBranchConfig.VersioningMode.GetInstance().GetPreReleaseTag(context, applicableTagsInDescendingOrder, numberOfCommitsSinceRelease);
+
+
             var semanticVersion = new SemanticVersion
             {
-                Major = versionFromMaster.Major,
-                Minor = versionFromMaster.Minor + 1,
-                Patch = 0,
-                PreReleaseTag = context.Configuration.DevelopBranchTag + numberOfCommitsSinceRelease,
+                Major = shortVersion.Major,
+                Minor = shortVersion.Minor,
+                Patch = shortVersion.Patch,
+                PreReleaseTag = preReleaseTag,
                 BuildMetaData = new SemanticVersionBuildMetaData(numberOfCommitsSinceRelease, context.CurrentBranch.Name,tip.Sha,tip.When()),
             };
 

--- a/GitVersionCore/GitFlow/BranchFinders/RecentTagVersionExtractor.cs
+++ b/GitVersionCore/GitFlow/BranchFinders/RecentTagVersionExtractor.cs
@@ -6,12 +6,6 @@ namespace GitVersion
 
     class RecentTagVersionExtractor
     {
-        internal static SemanticVersionPreReleaseTag RetrieveMostRecentOptionalTagVersion(GitVersionContext context, SemanticVersion matchVersion)
-        {
-            var tagsInDescendingOrder = context.Repository.SemVerTagsRelatedToVersion(context.Configuration, matchVersion).OrderByDescending(tag => SemanticVersion.Parse(tag.Name, context.Configuration.TagPrefix));
-            return RetrieveMostRecentOptionalTagVersion(context, tagsInDescendingOrder.ToList());
-        }
-
         internal static SemanticVersionPreReleaseTag RetrieveMostRecentOptionalTagVersion(GitVersionContext context, List<Tag> applicableTagsInDescendingOrder)
         {
             if (applicableTagsInDescendingOrder.Any())

--- a/GitVersionCore/GitFlow/BranchFinders/ReleaseVersionFinder.cs
+++ b/GitVersionCore/GitFlow/BranchFinders/ReleaseVersionFinder.cs
@@ -14,7 +14,7 @@ namespace GitVersion
 
             var applicableTagsInDescendingOrder = context.Repository.SemVerTagsRelatedToVersion(context.Configuration, shortVersion).OrderByDescending(tag => SemanticVersion.Parse(tag.Name, context.Configuration.TagPrefix)).ToList();
             var numberOfCommitsSinceLastTagOrBranchPoint = BranchCommitDifferenceFinder.NumberOfCommitsSinceLastTagOrBranchPoint(context, applicableTagsInDescendingOrder, BranchType.Release, "develop");
-            var semanticVersionPreReleaseTag = RecentTagVersionExtractor.RetrieveMostRecentOptionalTagVersion(context, applicableTagsInDescendingOrder) ?? context.Configuration.ReleaseBranchTag + ".1";
+            var semanticVersionPreReleaseTag = context.Configuration.Release.VersioningMode.GetInstance().GetPreReleaseTag(context, applicableTagsInDescendingOrder, numberOfCommitsSinceLastTagOrBranchPoint);
 
             return new SemanticVersion
             {

--- a/GitVersionCore/GitFlow/BranchFinders/ReleaseVersionFinder.cs
+++ b/GitVersionCore/GitFlow/BranchFinders/ReleaseVersionFinder.cs
@@ -14,7 +14,7 @@ namespace GitVersion
 
             var applicableTagsInDescendingOrder = context.Repository.SemVerTagsRelatedToVersion(context.Configuration, shortVersion).OrderByDescending(tag => SemanticVersion.Parse(tag.Name, context.Configuration.TagPrefix)).ToList();
             var numberOfCommitsSinceLastTagOrBranchPoint = BranchCommitDifferenceFinder.NumberOfCommitsSinceLastTagOrBranchPoint(context, applicableTagsInDescendingOrder, BranchType.Release, "develop");
-            var semanticVersionPreReleaseTag = context.Configuration.Release.VersioningMode.GetInstance().GetPreReleaseTag(context, applicableTagsInDescendingOrder, numberOfCommitsSinceLastTagOrBranchPoint);
+            var semanticVersionPreReleaseTag = context.Configuration.Branches["release[/-]"].VersioningMode.GetInstance().GetPreReleaseTag(context, applicableTagsInDescendingOrder, numberOfCommitsSinceLastTagOrBranchPoint);
 
             return new SemanticVersion
             {

--- a/GitVersionCore/GitFlow/GitFlowVersionFinder.cs
+++ b/GitVersionCore/GitFlow/GitFlowVersionFinder.cs
@@ -11,16 +11,19 @@ namespace GitVersion
 
             if (context.CurrentBranch.IsHotfix())
             {
+                context.CurrentBranchConfig = context.Configuration.Release;
                 return new HotfixVersionFinder().FindVersion(context);
             }
 
             if (context.CurrentBranch.IsRelease())
             {
+                context.CurrentBranchConfig = context.Configuration.Release;
                 return new ReleaseVersionFinder().FindVersion(context);
             }
 
             if (context.CurrentBranch.IsDevelop())
             {
+                context.CurrentBranchConfig = context.Configuration.Develop;
                 return new DevelopVersionFinder().FindVersion(context);
             }
 

--- a/GitVersionCore/GitFlow/GitFlowVersionFinder.cs
+++ b/GitVersionCore/GitFlow/GitFlowVersionFinder.cs
@@ -11,19 +11,19 @@ namespace GitVersion
 
             if (context.CurrentBranch.IsHotfix())
             {
-                context.CurrentBranchConfig = context.Configuration.Release;
+                context.CurrentBranchConfig = context.Configuration.Branches["release[/-]"];
                 return new HotfixVersionFinder().FindVersion(context);
             }
 
             if (context.CurrentBranch.IsRelease())
             {
-                context.CurrentBranchConfig = context.Configuration.Release;
+                context.CurrentBranchConfig = context.Configuration.Branches["release[/-]"];
                 return new ReleaseVersionFinder().FindVersion(context);
             }
 
             if (context.CurrentBranch.IsDevelop())
             {
-                context.CurrentBranchConfig = context.Configuration.Develop;
+                context.CurrentBranchConfig = context.Configuration.Branches["develop"];
                 return new DevelopVersionFinder().FindVersion(context);
             }
 

--- a/GitVersionCore/GitHubFlow/OtherBranchVersionFinder.cs
+++ b/GitVersionCore/GitHubFlow/OtherBranchVersionFinder.cs
@@ -23,7 +23,7 @@
 
             if (semanticVersionPreReleaseTag.Name == "release")
             {
-                semanticVersionPreReleaseTag.Name = context.Configuration.ReleaseBranchTag;
+                semanticVersionPreReleaseTag.Name = context.Configuration.Release.Tag;
             }
 
             semanticVersion = new SemanticVersion

--- a/GitVersionCore/GitHubFlow/OtherBranchVersionFinder.cs
+++ b/GitVersionCore/GitHubFlow/OtherBranchVersionFinder.cs
@@ -23,7 +23,7 @@
 
             if (semanticVersionPreReleaseTag.Name == "release")
             {
-                semanticVersionPreReleaseTag.Name = context.Configuration.Release.Tag;
+                semanticVersionPreReleaseTag.Name = context.Configuration.Branches["release[/-]"].Tag;
             }
 
             semanticVersion = new SemanticVersion

--- a/GitVersionCore/GitVersionContext.cs
+++ b/GitVersionCore/GitVersionContext.cs
@@ -40,6 +40,8 @@
         public Branch CurrentBranch { get; private set; }
         public Commit CurrentCommit { get; private set; }
 
+        public BranchConfig CurrentBranchConfig { get; set; }
+
         IEnumerable<Branch> GetBranchesContainingCommit(string commitSha)
         {
             var directBranchHasBeenFound = false;

--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -70,6 +70,7 @@
     <Compile Include="BuildServers\IBuildServer.cs" />
     <Compile Include="BuildServers\MyGet.cs" />
     <Compile Include="BuildServers\TeamCity.cs" />
+    <Compile Include="Configuration\BranchConfig.cs" />
     <Compile Include="Configuration\Config.cs" />
     <Compile Include="Configuration\ConfigReader.cs" />
     <Compile Include="Configuration\ConfigurationProvider.cs" />
@@ -79,6 +80,10 @@
     <Compile Include="Helpers\IFileSystem.cs" />
     <Compile Include="LastMinorVersionFinder.cs" />
     <Compile Include="SemanticVersionExtensions.cs" />
+    <Compile Include="VersioningModes\ContinuousDeliveryMode.cs" />
+    <Compile Include="VersioningModes\ContinuousDeploymentMode.cs" />
+    <Compile Include="VersioningModes\VersioningMode.cs" />
+    <Compile Include="VersioningModes\VersioningModeBase.cs" />
     <Compile Include="WarningException.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="GitDirFinder.cs" />

--- a/GitVersionCore/VersioningModes/ContinuousDeliveryMode.cs
+++ b/GitVersionCore/VersioningModes/ContinuousDeliveryMode.cs
@@ -1,0 +1,6 @@
+﻿namespace GitVersion.VersioningModes
+{
+    public class ContinuousDeliveryMode : VersioningModeBase
+    {
+    }
+}

--- a/GitVersionCore/VersioningModes/ContinuousDeliveryMode.cs
+++ b/GitVersionCore/VersioningModes/ContinuousDeliveryMode.cs
@@ -1,6 +1,15 @@
 ﻿namespace GitVersion.VersioningModes
 {
+    using System.Collections.Generic;
+
+    using LibGit2Sharp;
+
     public class ContinuousDeliveryMode : VersioningModeBase
     {
+        public override SemanticVersionPreReleaseTag GetPreReleaseTag(GitVersionContext context, List<Tag> possibleCommits, int numberOfCommits)
+        {
+            return RecentTagVersionExtractor.RetrieveMostRecentOptionalTagVersion(context, possibleCommits) 
+                ?? context.CurrentBranchConfig.Tag + ".1";
+        }
     }
 }

--- a/GitVersionCore/VersioningModes/ContinuousDeploymentMode.cs
+++ b/GitVersionCore/VersioningModes/ContinuousDeploymentMode.cs
@@ -1,6 +1,14 @@
 ﻿namespace GitVersion.VersioningModes
 {
+    using System.Collections.Generic;
+
+    using LibGit2Sharp;
+
     public class ContinuousDeploymentMode : VersioningModeBase
     {
+        public override SemanticVersionPreReleaseTag GetPreReleaseTag(GitVersionContext context, List<Tag> possibleTags, int numberOfCommits)
+        {
+            return context.CurrentBranchConfig.Tag + "." + numberOfCommits;
+        }
     }
 }

--- a/GitVersionCore/VersioningModes/ContinuousDeploymentMode.cs
+++ b/GitVersionCore/VersioningModes/ContinuousDeploymentMode.cs
@@ -1,0 +1,6 @@
+﻿namespace GitVersion.VersioningModes
+{
+    public class ContinuousDeploymentMode : VersioningModeBase
+    {
+    }
+}

--- a/GitVersionCore/VersioningModes/VersioningMode.cs
+++ b/GitVersionCore/VersioningModes/VersioningMode.cs
@@ -1,0 +1,8 @@
+﻿namespace GitVersion
+{
+    public enum VersioningMode
+    {
+        ContinuousDelivery,
+        ContinuousDeployment
+    }
+}

--- a/GitVersionCore/VersioningModes/VersioningMode.cs
+++ b/GitVersionCore/VersioningModes/VersioningMode.cs
@@ -1,8 +1,28 @@
 ﻿namespace GitVersion
 {
+    using System;
+
+    using GitVersion.VersioningModes;
+
     public enum VersioningMode
     {
         ContinuousDelivery,
         ContinuousDeployment
+    }
+
+    public static class VersioningModeExtension
+    {
+        public static VersioningModeBase GetInstance(this VersioningMode _this)
+        {
+            switch (_this)
+            {
+                case VersioningMode.ContinuousDelivery:
+                    return new ContinuousDeliveryMode();
+                case VersioningMode.ContinuousDeployment:
+                    return new ContinuousDeploymentMode();
+                default:
+                    throw new ArgumentException("No instance exists for this versioning mode.");
+            }
+        }
     }
 }

--- a/GitVersionCore/VersioningModes/VersioningModeBase.cs
+++ b/GitVersionCore/VersioningModes/VersioningModeBase.cs
@@ -1,6 +1,11 @@
 ﻿namespace GitVersion.VersioningModes
 {
+    using System.Collections.Generic;
+
+    using LibGit2Sharp;
+
     public abstract class VersioningModeBase
     {
+        public abstract SemanticVersionPreReleaseTag GetPreReleaseTag(GitVersionContext context, List<Tag> possibleTags, int numberOfCommits);
     }
 }

--- a/GitVersionCore/VersioningModes/VersioningModeBase.cs
+++ b/GitVersionCore/VersioningModes/VersioningModeBase.cs
@@ -1,0 +1,6 @@
+﻿namespace GitVersion.VersioningModes
+{
+    public abstract class VersioningModeBase
+    {
+    }
+}


### PR DESCRIPTION
As discussed #323 GitVersion should support different versioning modes which can be configured in the GitVersionConfig.yaml.

The modes are continuous deployment and continuous delivery.

As @JakeGinnivan says:
> Continuous deployment means you want each build to have a unique nuget version, continuous delivery means you do not.

At the moment the only difference is the pre-release tag. In continuous delivery the scheme is `<configured tag>.1` or if there is an applicable tag `<last-tag-name>-<last-tag-number>+1`. 
In continuous deployment the scheme is `<configured tag>.<nr of commits>`

What is still open:
- [ ] GitHub flow, how to handle those there?
- [ ] Feature branches, how is the scheme here?
- [ ] Are hotfix  branches "the same" as release branches?
- [ ] Support branches?
- [ ] Maybe find a better place than GitFlowVersionFInder for setting the `CurrentBranchConfig` property or maybe even find a better place for this property  than the `context`
- [ ] Do we need more than just the pre-release tag in the versioning mode?
- [ ] Can code be dropped?

Happy to see your comments and thoughts :smile: