### PR TITLE
Failing test case for feature branch name with a number

### DIFF
--- a/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="GitDirFinderTests.cs" />
     <Compile Include="Fixtures\BaseGitFlowRepositoryFixture.cs" />
     <Compile Include="IntegrationTests\GitFlow\DevelopScenarios.cs" />
+    <Compile Include="IntegrationTests\GitFlow\FeatureBranchTests.cs" />
     <Compile Include="IntegrationTests\GitFlow\SupportBranchScenarios.cs" />
     <Compile Include="IntegrationTests\GitFlow\MetaDataByCommitScenarios.cs" />
     <Compile Include="IntegrationTests\GitFlow\PatchScenarios.cs" />

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/FeatureBranchTests.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/FeatureBranchTests.cs
@@ -1,0 +1,32 @@
+using GitVersion;
+using LibGit2Sharp;
+using NUnit.Framework;
+
+[TestFixture]
+public class FeatureBranchTests
+{
+    [Test]
+    public void ShouldNotUseNumberInFeatureBranchAsPreReleaseNumber()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            fixture.Repository.MakeATaggedCommit("1.0.0");
+            fixture.Repository.CreateBranch("develop");
+            fixture.Repository.Checkout("develop");
+            fixture.Repository.CreateBranch("feature/JIRA-123");
+            fixture.Repository.Checkout("feature/JIRA-123");
+            fixture.Repository.MakeCommits(5);
+
+            // Current output 1.1.0-JIRA-.123+5
+
+            // A valid assert from my point of view
+            fixture.AssertFullSemver("1.1.0-JIRA-123.5");
+
+            // Or possible, but I'll guess it depends on wheter we're using a CD och CI flow?
+            // fixture.AssertFullSemver("1.1.0-JIRA-123+5");
+
+            // Or depending on how we treat the build number meta data
+            // fixture.AssertFullSemver("1.1.0-JIRA-123.5+5");
+        }
+    }    
+}


### PR DESCRIPTION
This is just a test to reproduce my issue with feature branches based on
the jira key e.g. feature/JIRA-123-a-description.

I'm not sure what a valid assert should look like, I have 3 examples I could live with, but the current output is broken from my point of view. What do you think would be a valid assert for this case?