### PR TITLE
WIP of WIP: first try to implement version strategies

### DIFF
--- a/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -115,7 +115,9 @@
     <Content Include="FodyWeavers.xml" />
     <Content Include="JsonVersionBuilderTests.Json.approved.txt" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/GitVersionCore/Configuration/BranchConfig.cs
+++ b/GitVersionCore/Configuration/BranchConfig.cs
@@ -1,13 +1,34 @@
-﻿namespace GitVersion
+﻿using GitVersion.Configuration;
+namespace GitVersion
 {
+    using System.Collections;
+    using System.Collections.Generic;
+
     using YamlDotNet.Serialization;
 
     public class BranchConfig
     {
+        public BranchConfig()
+        {
+            Prefixes = new List<string>();
+        }
+
         [YamlAlias("mode")]
         public VersioningMode VersioningMode { get; set; }
 
         [YamlAlias("tag")]
         public string Tag { get; set; }
+
+        public IncrementType IncrementType { get; set; }
+
+        public string ReferenceBranch { get; set; }
+
+        public IEnumerable<string> Prefixes { get; set; }
+
+        public string LastTagReferenceBranch { get; set; }
+
+        public bool IncrementOnTag { get; set; }
+
+        public bool ForceBuildMetdataFromReferenceBranch { get; set; }
     }
 }

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -4,6 +4,8 @@
     using System.Collections.Generic;
     using System.Linq;
 
+    using GitVersion.Configuration;
+
     using YamlDotNet.Serialization;
 
     public class Config
@@ -16,9 +18,55 @@
         {
             AssemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch;
             TagPrefix = "[vV]";
-            Branches["release[/-]"] = new BranchConfig { Tag = "beta" };
-            Branches["hotfix[/-]"] = new BranchConfig { Tag = "beta" };
-            Branches["develop"] = new BranchConfig { Tag = "unstable" };
+            Branches["release[/-]"] = new BranchConfig
+            {
+                Tag = "beta",
+                ReferenceBranch = "develop",
+                IncrementType = IncrementType.PreReleaseTag,
+                Prefixes = new List<string> { "release-", "release/" },
+                IncrementOnTag = false
+            };
+            Branches["develop"] = new BranchConfig
+            {
+                Tag = "unstable",
+                IncrementType = IncrementType.Minor,
+                ReferenceBranch = "master",
+                LastTagReferenceBranch = "master",
+                IncrementOnTag = true,
+                ForceBuildMetdataFromReferenceBranch = true
+            };
+            Branches["hotfix[/-]"] = new BranchConfig()
+            {
+                Tag = "beta",
+                ReferenceBranch = "master",
+                IncrementType = IncrementType.PreReleaseTag,
+                Prefixes = new List<string> { "hotifx-", "hotfix/" },
+                IncrementOnTag = false,
+                ForceBuildMetdataFromReferenceBranch = true
+            };
+            Branches["master"] = new BranchConfig()
+            {
+                Tag = ""
+            };
+            Branches["support[/-]"] = new BranchConfig()
+            {
+                Tag = "",
+                ReferenceBranch = "master"
+            };
+            Branches["feature[/-]"] = new BranchConfig()
+            {
+                Tag = "feature",
+                ReferenceBranch = "develop"
+            };
+            Branches["(pull)|(pull-requests)\\/"] = new BranchConfig()
+            {
+                Tag = "PullRequest",
+                IncrementType = IncrementType.Minor,
+                ReferenceBranch = "master",
+                LastTagReferenceBranch = "master",
+                IncrementOnTag = true,
+                ForceBuildMetdataFromReferenceBranch = true
+            };
             VersioningMode = VersioningMode.ContinuousDelivery;
             Develop.VersioningMode = VersioningMode.ContinuousDeployment;
         }

--- a/GitVersionCore/Configuration/IncrementType.cs
+++ b/GitVersionCore/Configuration/IncrementType.cs
@@ -1,0 +1,10 @@
+﻿namespace GitVersion.Configuration
+{
+    public enum IncrementType
+    {
+        Major,
+        Minor,
+        Patch,
+        PreReleaseTag
+    }
+}

--- a/GitVersionCore/GitFlow/BranchFinders/BranchCommitDifferenceFinder.cs
+++ b/GitVersionCore/GitFlow/BranchFinders/BranchCommitDifferenceFinder.cs
@@ -6,6 +6,11 @@ namespace GitVersion
 
     static class BranchCommitDifferenceFinder
     {
+        public static int NumberOfCommitsInBranchNotKnownFromBaseBranch(IRepository repo, Branch branch, string baseBranchName)
+        {
+            return NumberOfCommitsInBranchNotKnownFromBaseBranch(repo, branch, BranchType.Unknown, baseBranchName);
+        }
+
         public static int NumberOfCommitsInBranchNotKnownFromBaseBranch(IRepository repo, Branch branch, BranchType branchType, string baseBranchName)
         {
             var baseTip = repo.FindBranch(baseBranchName).Tip;
@@ -34,6 +39,11 @@ namespace GitVersion
 
             return repo.Commits.QueryBy(filter)
                 .Count();
+        }
+
+        public static int NumberOfCommitsSinceLastTagOrBranchPoint(GitVersionContext context, List<Tag> tagsInDescendingOrder, string baseBranchName)
+        {
+           return NumberOfCommitsSinceLastTagOrBranchPoint(context, tagsInDescendingOrder, BranchType.Unknown, baseBranchName);
         }
 
         public static int NumberOfCommitsSinceLastTagOrBranchPoint(GitVersionContext context, List<Tag> tagsInDescendingOrder, BranchType branchType,  string baseBranchName)

--- a/GitVersionCore/GitFlow/GitFlowVersionFinder.cs
+++ b/GitVersionCore/GitFlow/GitFlowVersionFinder.cs
@@ -1,5 +1,9 @@
 namespace GitVersion
 {
+    using System.Linq;
+
+    using GitVersion.VersionStrategies;
+
     public class GitFlowVersionFinder
     {
         public SemanticVersion FindVersion(GitVersionContext context)
@@ -11,17 +15,20 @@ namespace GitVersion
 
             if (context.CurrentBranch.IsHotfix())
             {
-                return new HotfixVersionFinder().FindVersion(context);
+                var versionStrategies = new VersionStrategyBase[] { new LastTagVersionStrategy(), new CurrentBranchNameVersionStrategy() };
+                return versionStrategies.Select(s => s.CalculateVersion(context)).Max();
             }
 
             if (context.CurrentBranch.IsRelease())
             {
-                return new ReleaseVersionFinder().FindVersion(context);
+                var versionStrategies = new VersionStrategyBase[] { new LastTagVersionStrategy(), new CurrentBranchNameVersionStrategy() };
+                return versionStrategies.Select(s => s.CalculateVersion(context)).Max();
             }
 
             if (context.CurrentBranch.IsDevelop())
             {
-                return new DevelopVersionFinder().FindVersion(context);
+                var versionStrategies = new VersionStrategyBase[] { new LastTagVersionStrategy(), new CurrentBranchNameVersionStrategy() };
+                return versionStrategies.Select(s => s.CalculateVersion(context)).Max();
             }
 
             if (context.CurrentBranch.IsPullRequest())

--- a/GitVersionCore/GitHubFlow/VersionTaggedCommit.cs
+++ b/GitVersionCore/GitHubFlow/VersionTaggedCommit.cs
@@ -4,11 +4,20 @@
 
     public class VersionTaggedCommit
     {
+        public Tag Tag;
         public Commit Commit;
         public SemanticVersion SemVer;
 
+
         public VersionTaggedCommit(Commit commit, SemanticVersion semVer)
         {
+            Commit = commit;
+            SemVer = semVer;
+        }
+
+        public VersionTaggedCommit(Commit commit, SemanticVersion semVer, Tag tag)
+        {
+            Tag = tag;
             Commit = commit;
             SemVer = semVer;
         }

--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Configuration\Config.cs" />
     <Compile Include="Configuration\ConfigReader.cs" />
     <Compile Include="Configuration\ConfigurationProvider.cs" />
+    <Compile Include="Configuration\IncrementType.cs" />
     <Compile Include="GitFlow\BranchFinders\BranchCommitDifferenceFinder.cs" />
     <Compile Include="GitFlow\BranchFinders\RecentTagVersionExtractor.cs" />
     <Compile Include="Helpers\FileSystem.cs" />
@@ -85,6 +86,9 @@
     <Compile Include="VersioningModes\ContinuousDeploymentMode.cs" />
     <Compile Include="VersioningModes\VersioningMode.cs" />
     <Compile Include="VersioningModes\VersioningModeBase.cs" />
+    <Compile Include="VersionStrategies\CurrentBranchNameVersionStrategy.cs" />
+    <Compile Include="VersionStrategies\LastTagVersionStrategy.cs" />
+    <Compile Include="VersionStrategies\VersionStrategyBase.cs" />
     <Compile Include="WarningException.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="GitDirFinder.cs" />

--- a/GitVersionCore/VersionStrategies/CurrentBranchNameVersionStrategy.cs
+++ b/GitVersionCore/VersionStrategies/CurrentBranchNameVersionStrategy.cs
@@ -1,0 +1,34 @@
+namespace GitVersion.VersionStrategies
+{
+    using System.Linq;
+
+    using LibGit2Sharp;
+
+    public class CurrentBranchNameVersionStrategy : VersionStrategyBase
+    {
+        public override SemanticVersion CalculateVersion(GitVersionContext context)
+        {
+            
+            var versionString = GetSuffix(context, context.CurrentBranch);
+            SemanticVersion shortVersion;
+            if (SemanticVersion.TryParse(versionString, context.Configuration.TagPrefix, out shortVersion))
+            {
+                var nbHotfixCommits = BranchCommitDifferenceFinder.NumberOfCommitsInBranchNotKnownFromBaseBranch(context.Repository, context.CurrentBranch, context.CurrentBranchConfig.ReferenceBranch);
+                return new SemanticVersion
+                           {
+                               Major = shortVersion.Major,
+                               Minor = shortVersion.Minor,
+                               Patch = shortVersion.Patch,
+                               PreReleaseTag = new SemanticVersionPreReleaseTag(context.CurrentBranchConfig.Tag, 1),
+                               BuildMetaData = new SemanticVersionBuildMetaData(nbHotfixCommits, context.CurrentBranch.Name, context.CurrentCommit.Sha, context.CurrentCommit.When())
+                           };
+            }
+            return null;
+        }
+
+        static string GetSuffix(GitVersionContext context, Branch branch)
+        {
+            return context.CurrentBranchConfig.Prefixes.Aggregate(branch.Name, (seed, prefix) => ExtensionMethods.TrimStart(seed, prefix));
+        }
+    }
+}

--- a/GitVersionCore/VersionStrategies/LastTagVersionStrategy.cs
+++ b/GitVersionCore/VersionStrategies/LastTagVersionStrategy.cs
@@ -1,0 +1,103 @@
+﻿namespace GitVersion.VersionStrategies
+{
+    using System.Linq;
+
+    using GitVersion.Configuration;
+
+    using LibGit2Sharp;
+
+    public class LastTagVersionStrategy : VersionStrategyBase
+    {
+        public override SemanticVersion CalculateVersion(GitVersionContext context)
+        {
+            var lastTaggedCommit = this.GetLastTaggedCommit(context);
+            if (lastTaggedCommit == null) return null;
+
+            var version = lastTaggedCommit.SemVer;
+
+            int numberOfCommitsSinceRelease;
+
+            if (lastTaggedCommit.Commit != context.CurrentCommit || context.CurrentBranchConfig.IncrementOnTag)
+            {
+                switch (context.CurrentBranchConfig.IncrementType)
+                {
+                    case IncrementType.Major:
+                        version.Major++;
+                        version.Minor = 0;
+                        version.Patch = 0;
+                        version.PreReleaseTag = new SemanticVersionPreReleaseTag(context.CurrentBranchConfig.Tag, 1);
+                        break;
+                    case IncrementType.Minor:
+                        version.Minor++;
+                        version.Patch = 0;
+                        version.PreReleaseTag = new SemanticVersionPreReleaseTag(context.CurrentBranchConfig.Tag, 1);
+                        break;
+                    case IncrementType.Patch:
+                        version.Patch++;
+                        version.PreReleaseTag = new SemanticVersionPreReleaseTag(context.CurrentBranchConfig.Tag, 1);
+                        break;
+                    case IncrementType.PreReleaseTag:
+                        version.PreReleaseTag.Number++;
+                        break;
+                }
+
+                var until = lastTaggedCommit.Commit;
+                if (context.CurrentBranchConfig.ForceBuildMetdataFromReferenceBranch)
+                {
+                    until = context.Repository.FindBranch(context.CurrentBranchConfig.ReferenceBranch).Tip;
+                }
+
+                var f = new CommitFilter
+                            {
+                                Since = context.CurrentCommit,
+                                Until = until,
+                                SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Time
+                            };
+
+                var c = context.Repository.Commits.QueryBy(f);
+                numberOfCommitsSinceRelease = c.Count();
+                if (!context.CurrentBranchConfig.ForceBuildMetdataFromReferenceBranch)
+                {
+                    numberOfCommitsSinceRelease--;
+                }
+            }
+            else
+            {
+                var applicableTagsInDescendingOrder = context.Repository.SemVerTagsRelatedToVersion(context.Configuration, version).OrderByDescending(tag => SemanticVersion.Parse(tag.Name, context.Configuration.TagPrefix)).ToList();
+                numberOfCommitsSinceRelease = BranchCommitDifferenceFinder.NumberOfCommitsSinceLastTagOrBranchPoint(context, applicableTagsInDescendingOrder, BranchType.Unknown, context.CurrentBranchConfig.ReferenceBranch);// (context, applicableTagsInDescendingOrder, BranchType.Release, context.CurrentBranchConfig.ReferenceBranch);
+            }
+            var tip = context.CurrentCommit;
+            version.BuildMetaData = new SemanticVersionBuildMetaData(numberOfCommitsSinceRelease, context.CurrentBranch.Name, tip.Sha, tip.When());
+            return version;
+        }
+
+        protected VersionTaggedCommit GetLastTaggedCommit(GitVersionContext context)
+        {
+            var branch = string.IsNullOrEmpty(context.CurrentBranchConfig.LastTagReferenceBranch) 
+                ? context.CurrentBranch 
+                : context.Repository.Branches[context.CurrentBranchConfig.LastTagReferenceBranch];
+
+            var tags = context.Repository.Tags.Select(t =>
+            {
+                SemanticVersion version;
+                if (SemanticVersion.TryParse(t.Name, context.Configuration.TagPrefix, out version))
+                {
+                    return new VersionTaggedCommit((Commit)t.Target, version, t);
+                }
+                return null;
+            })
+               .Where(a => a != null)
+               .ToArray();
+            var olderThan = context.CurrentCommit.When();
+            var lastTaggedCommit =
+                branch.Commits.FirstOrDefault(c => c.When() <= olderThan && tags.Any(a => a.Commit == c));
+
+            if (lastTaggedCommit != null)
+            {
+                return tags.Last(a => a.Commit.Sha == lastTaggedCommit.Sha);
+            }
+
+            return null;
+        }
+    }
+}

--- a/GitVersionCore/VersionStrategies/VersionStrategyBase.cs
+++ b/GitVersionCore/VersionStrategies/VersionStrategyBase.cs
@@ -1,0 +1,7 @@
+﻿namespace GitVersion.VersionStrategies
+{
+    public abstract class VersionStrategyBase
+    {
+        public abstract SemanticVersion CalculateVersion(GitVersionContext context);
+    }
+}

--- a/GitVersionExe.Tests/GitVersionExe.Tests.csproj
+++ b/GitVersionExe.Tests/GitVersionExe.Tests.csproj
@@ -85,6 +85,9 @@
     <Compile Include="PullRequestInTeamCityTest.cs" />
     <Compile Include="AssemblyInfoFileUpdateTests.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>


### PR DESCRIPTION
Currently this code breaks a lot of tests. 

The main reason for this, is that on the develop, for the prerelease tag, the same strategy will be used as for release/hotfixes: if there is no tag, the prerelease tag is unstable.1. 