### PR TITLE
Config based versioning

### DIFF
--- a/GitVersionCore.Tests/GitVersionContextBuilder.cs
+++ b/GitVersionCore.Tests/GitVersionContextBuilder.cs
@@ -29,6 +29,18 @@
             return this;
         }
 
+        public GitVersionContextBuilder WithDevelopBranch()
+        {
+            repository = CreateRepository();
+            var mockBranch = new MockBranch("develop")
+            {
+                new MockCommit()
+            };
+            ((MockBranchCollection) repository.Branches).Add(mockBranch);
+            ((MockRepository)repository).Head = mockBranch;
+            return this;
+        }
+
         public GitVersionContext Build()
         {
             return new GitVersionContext(repository ?? CreateRepository(), config ?? new Config());

--- a/GitVersionCore.Tests/GitVersionContextBuilder.cs
+++ b/GitVersionCore.Tests/GitVersionContextBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace GitVersionCore.Tests.VersionCalculation.Strategies
+﻿namespace GitVersionCore.Tests
 {
     using GitVersion;
     using LibGit2Sharp;
@@ -20,6 +20,15 @@
             return this;
         }
 
+        public GitVersionContextBuilder WithTaggedMaster()
+        {
+            repository = CreateRepository();
+            var target = repository.Head.Tip;
+            ((MockTagCollection)repository.Tags).Add(new MockTag ("1.0.0", target));
+            ((MockBranch)repository.Head).Add(new MockCommit { CommitterEx = SignatureBuilder.SignatureNow() });
+            return this;
+        }
+
         public GitVersionContext Build()
         {
             return new GitVersionContext(repository ?? CreateRepository(), config ?? new Config());
@@ -34,6 +43,7 @@
                 {
                     mockBranch
                 },
+                Tags = new MockTagCollection(),
                 Head = mockBranch
             };
 

--- a/GitVersionCore.Tests/GitVersionContextBuilder.cs
+++ b/GitVersionCore.Tests/GitVersionContextBuilder.cs
@@ -29,14 +29,25 @@
             return this;
         }
 
+        public GitVersionContextBuilder AddCommit()
+        {
+            ((MockBranch)repository.Head).Add(new MockCommit());
+            return this;
+        }
+
         public GitVersionContextBuilder WithDevelopBranch()
         {
+            return WithBranch("develop");
+        }
+
+        public GitVersionContextBuilder WithBranch(string branchName)
+        {
             repository = CreateRepository();
-            var mockBranch = new MockBranch("develop")
+            var mockBranch = new MockBranch(branchName)
             {
                 new MockCommit()
             };
-            ((MockBranchCollection) repository.Branches).Add(mockBranch);
+            ((MockBranchCollection)repository.Branches).Add(mockBranch);
             ((MockRepository)repository).Head = mockBranch;
             return this;
         }

--- a/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -121,6 +121,8 @@
     <Compile Include="GitVersionContextBuilder.cs" />
     <Compile Include="VersionCalculation\Strategies\LastTagBaseVersionStrategyTests.cs" />
     <Compile Include="VersionCalculation\Strategies\MergeMessageBaseVersionStrategyTests.cs" />
+    <Compile Include="VersionCalculation\TestBaseVersionCalculator.cs" />
+    <Compile Include="VersionCalculation\TestMetaDataCalculator.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -115,6 +115,9 @@
     <Compile Include="TestEffectiveConfiguration.cs" />
     <Compile Include="TestFileSystem.cs" />
     <Compile Include="VariableProviderTests.cs" />
+    <Compile Include="VersionCalculation\BaseVersionCalculatorTests.cs" />
+    <Compile Include="VersionCalculation\Strategies\ConfigNextVersionBaseVersionStrategyTests.cs" />
+    <Compile Include="VersionCalculation\Strategies\GitVersionContextBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="VersionCalculation\BaseVersionCalculatorTests.cs" />
     <Compile Include="VersionCalculation\Strategies\ConfigNextVersionBaseVersionStrategyTests.cs" />
     <Compile Include="VersionCalculation\Strategies\GitVersionContextBuilder.cs" />
+    <Compile Include="VersionCalculation\Strategies\MergeMessageBaseVersionStrategyTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="TestFileSystem.cs" />
     <Compile Include="VariableProviderTests.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculatorTests.cs" />
+    <Compile Include="VersionCalculation\NewNextVersionCalculatorTests.cs" />
     <Compile Include="VersionCalculation\Strategies\ConfigNextVersionBaseVersionStrategyTests.cs" />
     <Compile Include="GitVersionContextBuilder.cs" />
     <Compile Include="VersionCalculation\Strategies\LastTagBaseVersionStrategyTests.cs" />

--- a/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -121,6 +121,7 @@
     <Compile Include="GitVersionContextBuilder.cs" />
     <Compile Include="VersionCalculation\Strategies\LastTagBaseVersionStrategyTests.cs" />
     <Compile Include="VersionCalculation\Strategies\MergeMessageBaseVersionStrategyTests.cs" />
+    <Compile Include="VersionCalculation\Strategies\VersionInBranchBaseVersionStrategyTests.cs" />
     <Compile Include="VersionCalculation\TestBaseVersionCalculator.cs" />
     <Compile Include="VersionCalculation\TestMetaDataCalculator.cs" />
   </ItemGroup>

--- a/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -117,7 +117,8 @@
     <Compile Include="VariableProviderTests.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculatorTests.cs" />
     <Compile Include="VersionCalculation\Strategies\ConfigNextVersionBaseVersionStrategyTests.cs" />
-    <Compile Include="VersionCalculation\Strategies\GitVersionContextBuilder.cs" />
+    <Compile Include="GitVersionContextBuilder.cs" />
+    <Compile Include="VersionCalculation\Strategies\LastTagBaseVersionStrategyTests.cs" />
     <Compile Include="VersionCalculation\Strategies\MergeMessageBaseVersionStrategyTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/GitVersionCore.Tests/Mocks/MockTag.cs
+++ b/GitVersionCore.Tests/Mocks/MockTag.cs
@@ -15,6 +15,15 @@ public class MockTag : Tag
         get { return TargetEx; }
     }
     public TagAnnotation AnnotationEx;
+
+    public MockTag() { }
+
+    public MockTag(string name, Commit target)
+    {
+        NameEx = name;
+        TargetEx = target;
+    }
+
     public override TagAnnotation Annotation
     {
         get { return AnnotationEx; }

--- a/GitVersionCore.Tests/TestEffectiveConfiguration.cs
+++ b/GitVersionCore.Tests/TestEffectiveConfiguration.cs
@@ -10,7 +10,7 @@ namespace GitVersionCore.Tests
             string gitTagPrefix = "v", 
             string tag = "",
             string nextVersion = null) : 
-                base(assemblyVersioningScheme, versioningMode, gitTagPrefix, tag, nextVersion)
+                base(assemblyVersioningScheme, versioningMode, gitTagPrefix, tag, nextVersion, IncrementStrategy.Patch)
         {
         }
     }

--- a/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
@@ -1,0 +1,41 @@
+﻿namespace GitVersionCore.Tests.VersionCalculation
+{
+    using GitVersion;
+    using GitVersion.VersionCalculation;
+    using GitVersion.VersionCalculation.BaseVersionCalculators;
+    using GitVersionCore.Tests.VersionCalculation.Strategies;
+    using NUnit.Framework;
+    using Shouldly;
+
+    [TestFixture]
+    public class BaseVersionCalculatorTests
+    {
+        [Test]
+        public void ChoosesHighestVersionReturnedFromStrategies()
+        {
+            var context = new GitVersionContextBuilder().Build();
+            var sut = new BaseVersionCalculator(new V1Strategy(), new V2Strategy());
+
+            var baseVersion = sut.GetBaseVersion(context);
+
+            baseVersion.SemanticVersion.ToString().ShouldBe("2.0.0");
+            baseVersion.ShouldIncrement.ShouldBe(true);
+        }
+
+        class V1Strategy : BaseVersionStrategy
+        {
+            public override BaseVersion GetVersion(GitVersionContext context)
+            {
+                return new BaseVersion(false, new SemanticVersion(1));
+            }
+        }
+
+        class V2Strategy : BaseVersionStrategy
+        {
+            public override BaseVersion GetVersion(GitVersionContext context)
+            {
+                return new BaseVersion(true, new SemanticVersion(2));
+            }
+        }
+    }
+}

--- a/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace GitVersionCore.Tests.VersionCalculation
 {
+    using System;
     using GitVersion;
     using GitVersion.VersionCalculation;
     using GitVersion.VersionCalculation.BaseVersionCalculators;
@@ -13,27 +14,71 @@
         public void ChoosesHighestVersionReturnedFromStrategies()
         {
             var context = new GitVersionContextBuilder().Build();
-            var sut = new BaseVersionCalculator(new V1Strategy(), new V2Strategy());
+            var dateTimeOffset = DateTimeOffset.Now;
+            var sut = new BaseVersionCalculator(new V1Strategy(DateTimeOffset.Now), new V2Strategy(dateTimeOffset));
 
             var baseVersion = sut.GetBaseVersion(context);
 
             baseVersion.SemanticVersion.ToString().ShouldBe("2.0.0");
             baseVersion.ShouldIncrement.ShouldBe(true);
+            baseVersion.BaseVersionWhenFrom.ShouldBe(dateTimeOffset);
+        }
+
+        [Test]
+        public void UsesWhenFromNextBestMatchIfHighestDoesntHaveWhen()
+        {
+            var context = new GitVersionContextBuilder().Build();
+            var when = DateTimeOffset.Now;
+            var sut = new BaseVersionCalculator(new V1Strategy(when), new V2Strategy(null));
+
+            var baseVersion = sut.GetBaseVersion(context);
+
+            baseVersion.SemanticVersion.ToString().ShouldBe("2.0.0");
+            baseVersion.ShouldIncrement.ShouldBe(true);
+            baseVersion.BaseVersionWhenFrom.ShouldBe(when);
+        }
+
+        [Test]
+        public void UsesWhenFromNextBestMatchIfHighestDoesntHaveWhenReversedOrder()
+        {
+            var context = new GitVersionContextBuilder().Build();
+            var when = DateTimeOffset.Now;
+            var sut = new BaseVersionCalculator(new V1Strategy(null), new V2Strategy(when));
+
+            var baseVersion = sut.GetBaseVersion(context);
+
+            baseVersion.SemanticVersion.ToString().ShouldBe("2.0.0");
+            baseVersion.ShouldIncrement.ShouldBe(true);
+            baseVersion.BaseVersionWhenFrom.ShouldBe(when);
         }
 
         class V1Strategy : BaseVersionStrategy
         {
+            readonly DateTimeOffset? when;
+
+            public V1Strategy(DateTimeOffset? when)
+            {
+                this.when = when;
+            }
+
             public override BaseVersion GetVersion(GitVersionContext context)
             {
-                return new BaseVersion(false, new SemanticVersion(1));
+                return new BaseVersion(false, new SemanticVersion(1), when);
             }
         }
 
         class V2Strategy : BaseVersionStrategy
         {
+            DateTimeOffset? when;
+
+            public V2Strategy(DateTimeOffset? when)
+            {
+                this.when = when;
+            }
+
             public override BaseVersion GetVersion(GitVersionContext context)
             {
-                return new BaseVersion(true, new SemanticVersion(2));
+                return new BaseVersion(true, new SemanticVersion(2), when);
             }
         }
     }

--- a/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
@@ -4,6 +4,7 @@
     using GitVersion;
     using GitVersion.VersionCalculation;
     using GitVersion.VersionCalculation.BaseVersionCalculators;
+    using LibGit2Sharp;
     using NUnit.Framework;
     using Shouldly;
 
@@ -21,7 +22,7 @@
 
             baseVersion.SemanticVersion.ToString().ShouldBe("2.0.0");
             baseVersion.ShouldIncrement.ShouldBe(true);
-            baseVersion.BaseVersionWhenFrom.ShouldBe(dateTimeOffset);
+            baseVersion.BaseVersionSource.When().ShouldBe(dateTimeOffset);
         }
 
         [Test]
@@ -35,7 +36,7 @@
 
             baseVersion.SemanticVersion.ToString().ShouldBe("2.0.0");
             baseVersion.ShouldIncrement.ShouldBe(true);
-            baseVersion.BaseVersionWhenFrom.ShouldBe(when);
+            baseVersion.BaseVersionSource.When().ShouldBe(when);
         }
 
         [Test]
@@ -49,16 +50,16 @@
 
             baseVersion.SemanticVersion.ToString().ShouldBe("2.0.0");
             baseVersion.ShouldIncrement.ShouldBe(true);
-            baseVersion.BaseVersionWhenFrom.ShouldBe(when);
+            baseVersion.BaseVersionSource.When().ShouldBe(when);
         }
 
         class V1Strategy : BaseVersionStrategy
         {
-            readonly DateTimeOffset? when;
+            readonly Commit when;
 
             public V1Strategy(DateTimeOffset? when)
             {
-                this.when = when;
+                this.when = when == null ? null : new MockCommit { CommitterEx = when.Value.ToSignature() };
             }
 
             public override BaseVersion GetVersion(GitVersionContext context)
@@ -69,11 +70,11 @@
 
         class V2Strategy : BaseVersionStrategy
         {
-            DateTimeOffset? when;
+            Commit when;
 
             public V2Strategy(DateTimeOffset? when)
             {
-                this.when = when;
+                this.when = when == null ? null : new MockCommit { CommitterEx = when.Value.ToSignature() };
             }
 
             public override BaseVersion GetVersion(GitVersionContext context)

--- a/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
@@ -3,7 +3,6 @@
     using GitVersion;
     using GitVersion.VersionCalculation;
     using GitVersion.VersionCalculation.BaseVersionCalculators;
-    using GitVersionCore.Tests.VersionCalculation.Strategies;
     using NUnit.Framework;
     using Shouldly;
 

--- a/GitVersionCore.Tests/VersionCalculation/NewNextVersionCalculatorTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/NewNextVersionCalculatorTests.cs
@@ -1,0 +1,44 @@
+﻿namespace GitVersionCore.Tests.VersionCalculation
+{
+    using GitVersion;
+    using GitVersion.VersionCalculation;
+    using NUnit.Framework;
+    using Shouldly;
+
+    public class NewNextVersionCalculatorTests
+    {
+        [Test]
+        public void ShouldIncrementVersionBasedOnConfig()
+        {
+            var baseCalculator = new TestBaseVersionCalculator(true, new SemanticVersion(1));
+            var sut = new NewNextVersionCalculator(baseCalculator);
+            var config = new Config();
+            config.Branches.Add("master", new BranchConfig
+            {
+                Increment = IncrementStrategy.Major
+            });
+            var context = new GitVersionContextBuilder().WithConfig(config).Build();
+
+            var version = sut.FindVersion(context);
+
+            version.ToString().ShouldBe("2.0.0");
+        }
+
+        [Test]
+        public void DoesNotIncrementWhenBaseVersionSaysNotTo()
+        {
+            var baseCalculator = new TestBaseVersionCalculator(false, new SemanticVersion(1));
+            var sut = new NewNextVersionCalculator(baseCalculator);
+            var config = new Config();
+            config.Branches.Add("master", new BranchConfig
+            {
+                Increment = IncrementStrategy.Major
+            });
+            var context = new GitVersionContextBuilder().WithConfig(config).Build();
+
+            var version = sut.FindVersion(context);
+
+            version.ToString().ShouldBe("1.0.0");
+        }
+    }
+}

--- a/GitVersionCore.Tests/VersionCalculation/NewNextVersionCalculatorTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/NewNextVersionCalculatorTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace GitVersionCore.Tests.VersionCalculation
 {
+    using System;
     using GitVersion;
     using GitVersion.VersionCalculation;
     using NUnit.Framework;
@@ -10,8 +11,9 @@
         [Test]
         public void ShouldIncrementVersionBasedOnConfig()
         {
-            var baseCalculator = new TestBaseVersionCalculator(true, new SemanticVersion(1));
-            var sut = new NewNextVersionCalculator(baseCalculator);
+            var baseCalculator = new TestBaseVersionCalculator(true, new SemanticVersion(1), DateTimeOffset.Now);
+            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData(1, "master", "b1a34e", DateTimeOffset.Now);
+            var sut = new NewNextVersionCalculator(baseCalculator, new TestMetaDataCalculator(semanticVersionBuildMetaData));
             var config = new Config();
             config.Branches.Add("master", new BranchConfig
             {
@@ -27,8 +29,9 @@
         [Test]
         public void DoesNotIncrementWhenBaseVersionSaysNotTo()
         {
-            var baseCalculator = new TestBaseVersionCalculator(false, new SemanticVersion(1));
-            var sut = new NewNextVersionCalculator(baseCalculator);
+            var baseCalculator = new TestBaseVersionCalculator(false, new SemanticVersion(1), DateTimeOffset.Now);
+            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData(1, "master", "b1a34e", DateTimeOffset.Now);
+            var sut = new NewNextVersionCalculator(baseCalculator, new TestMetaDataCalculator(semanticVersionBuildMetaData));
             var config = new Config();
             config.Branches.Add("master", new BranchConfig
             {

--- a/GitVersionCore.Tests/VersionCalculation/NewNextVersionCalculatorTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/NewNextVersionCalculatorTests.cs
@@ -11,7 +11,7 @@
         [Test]
         public void ShouldIncrementVersionBasedOnConfig()
         {
-            var baseCalculator = new TestBaseVersionCalculator(true, new SemanticVersion(1), DateTimeOffset.Now);
+            var baseCalculator = new TestBaseVersionCalculator(true, new SemanticVersion(1), new MockCommit());
             var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData(1, "master", "b1a34e", DateTimeOffset.Now);
             var sut = new NewNextVersionCalculator(baseCalculator, new TestMetaDataCalculator(semanticVersionBuildMetaData));
             var config = new Config();
@@ -29,7 +29,7 @@
         [Test]
         public void DoesNotIncrementWhenBaseVersionSaysNotTo()
         {
-            var baseCalculator = new TestBaseVersionCalculator(false, new SemanticVersion(1), DateTimeOffset.Now);
+            var baseCalculator = new TestBaseVersionCalculator(false, new SemanticVersion(1), new MockCommit());
             var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData(1, "master", "b1a34e", DateTimeOffset.Now);
             var sut = new NewNextVersionCalculator(baseCalculator, new TestMetaDataCalculator(semanticVersionBuildMetaData));
             var config = new Config();
@@ -42,6 +42,21 @@
             var version = sut.FindVersion(context);
 
             version.ToString().ShouldBe("1.0.0");
+        }
+
+        [Test]
+        public void AppliesBranchPreReleaseTag()
+        {
+            var baseCalculator = new TestBaseVersionCalculator(false, new SemanticVersion(1), new MockCommit());
+            var semanticVersionBuildMetaData = new SemanticVersionBuildMetaData(1, "develop", "b1a34e", DateTimeOffset.Now);
+            var sut = new NewNextVersionCalculator(baseCalculator, new TestMetaDataCalculator(semanticVersionBuildMetaData));
+            var context = new GitVersionContextBuilder()
+                .WithDevelopBranch()
+                .Build();
+
+            var version = sut.FindVersion(context);
+
+            version.ToString().ShouldBe("1.0.0-unstable.1");
         }
     }
 }

--- a/GitVersionCore.Tests/VersionCalculation/Strategies/ConfigNextVersionBaseVersionStrategyTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/ConfigNextVersionBaseVersionStrategyTests.cs
@@ -1,0 +1,38 @@
+﻿namespace GitVersionCore.Tests.VersionCalculation.Strategies
+{
+    using GitVersion;
+    using GitVersion.VersionCalculation.BaseVersionCalculators;
+    using NUnit.Framework;
+    using Shouldly;
+
+    [TestFixture]
+    public class ConfigNextVersionBaseVersionStrategyTests
+    {
+        [Test]
+        public void ShouldNotBeIncremented()
+        {
+            var contextBuilder = new GitVersionContextBuilder()
+                .WithConfig(new Config
+                {
+                    NextVersion = "1.0.0"
+                });
+            var sut = new ConfigNextVersionBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersion(contextBuilder.Build());
+
+            baseVersion.ShouldIncrement.ShouldBe(false);
+            baseVersion.SemanticVersion.ToString().ShouldBe("1.0.0");
+        }
+
+        [Test]
+        public void ReturnsNullWhenNoNextVersionIsInConfig()
+        {
+            var contextBuilder = new GitVersionContextBuilder();
+            var sut = new ConfigNextVersionBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersion(contextBuilder.Build());
+
+            baseVersion.ShouldBe(null);
+        }
+    }
+}

--- a/GitVersionCore.Tests/VersionCalculation/Strategies/GitVersionContextBuilder.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/GitVersionContextBuilder.cs
@@ -1,0 +1,43 @@
+﻿namespace GitVersionCore.Tests.VersionCalculation.Strategies
+{
+    using GitVersion;
+    using LibGit2Sharp;
+
+    public class GitVersionContextBuilder
+    {
+        IRepository repository;
+        Config config;
+
+        public GitVersionContextBuilder WithRepository(IRepository repository)
+        {
+            this.repository = repository;
+            return this;
+        }
+
+        public GitVersionContextBuilder WithConfig(Config config)
+        {
+            this.config = config;
+            return this;
+        }
+
+        public GitVersionContext Build()
+        {
+            return new GitVersionContext(repository ?? CreateRepository(), config ?? new Config());
+        }
+
+        IRepository CreateRepository()
+        {
+            var mockBranch = new MockBranch("master") { new MockCommit { CommitterEx = SignatureBuilder.SignatureNow() } };
+            var mockRepository = new MockRepository
+            {
+                Branches = new MockBranchCollection
+                {
+                    mockBranch
+                },
+                Head = mockBranch
+            };
+
+            return mockRepository;
+        }
+    }
+}

--- a/GitVersionCore.Tests/VersionCalculation/Strategies/LastTagBaseVersionStrategyTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/LastTagBaseVersionStrategyTests.cs
@@ -8,7 +8,21 @@
     public class LastTagBaseVersionStrategyTests
     {
         [Test]
-        public void ShouldAllowVersionIncremenet()
+        public void ShouldAllowVersionIncrement()
+        {
+            var context = new GitVersionContextBuilder()
+                .WithTaggedMaster()
+                .AddCommit()
+                .Build();
+            var sut = new LastTagBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersion(context);
+
+            baseVersion.ShouldIncrement.ShouldBe(true);
+        }
+
+        [Test]
+        public void ShouldNotAllowVersionIncrementWhenTagComesFromCurrentCommit()
         {
             var context = new GitVersionContextBuilder()
                 .WithTaggedMaster()
@@ -17,7 +31,7 @@
 
             var baseVersion = sut.GetVersion(context);
 
-            baseVersion.ShouldIncrement.ShouldBe(true);
+            baseVersion.ShouldIncrement.ShouldBe(false);
         }
     }
 }

--- a/GitVersionCore.Tests/VersionCalculation/Strategies/LastTagBaseVersionStrategyTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/LastTagBaseVersionStrategyTests.cs
@@ -1,0 +1,23 @@
+﻿namespace GitVersionCore.Tests.VersionCalculation.Strategies
+{
+    using GitVersion.VersionCalculation.BaseVersionCalculators;
+    using NUnit.Framework;
+    using Shouldly;
+
+    [TestFixture]
+    public class LastTagBaseVersionStrategyTests
+    {
+        [Test]
+        public void ShouldAllowVersionIncremenet()
+        {
+            var context = new GitVersionContextBuilder()
+                .WithTaggedMaster()
+                .Build();
+            var sut = new LastTagBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersion(context);
+
+            baseVersion.ShouldIncrement.ShouldBe(true);
+        }
+    }
+}

--- a/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -70,7 +70,11 @@
             var context = new GitVersionContextBuilder()
                 .WithRepository(new MockRepository
                 {
-                    Head = new MockBranch("master") { commit }
+                    Head = new MockBranch("master")
+                    {
+                        commit,
+                        new MockCommit()
+                    }
                 })
                 .Build();
             var sut = new MergeMessageBaseVersionStrategy();

--- a/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -1,0 +1,106 @@
+﻿namespace GitVersionCore.Tests.VersionCalculation.Strategies
+{
+    using System.Collections.Generic;
+    using GitVersion.VersionCalculation.BaseVersionCalculators;
+    using LibGit2Sharp;
+    using NUnit.Framework;
+    using Shouldly;
+
+    [TestFixture]
+    public class MergeMessageBaseVersionStrategyTests
+    {
+        [Test]
+        public void ShouldAllowIncrementOfVersion()
+        {
+            var context = new GitVersionContextBuilder().WithRepository(new MockRepository
+            {
+                Head = new MockBranch("master") { new MockCommit
+                {
+                    MessageEx = "Merge branch 'hotfix-0.1.5'",
+                    ParentsEx = GetParents(true)
+                } }
+            }).Build();
+            var sut = new MergeMessageBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersion(context);
+
+            baseVersion.ShouldIncrement.ShouldBe(true);
+        }
+
+        [TestCase("Merge branch 'hotfix-0.1.5'", false, null)]
+        [TestCase("Merge branch 'develop' of github.com:Particular/NServiceBus into develop", true, null)]
+        [TestCase("Merge branch '4.0.3'", true, "4.0.3")] //TODO: possible make it a config option to support this
+        [TestCase("Merge branch 'release-10.10.50'", true, "10.10.50")]
+        [TestCase("Merge branch 's'", true, null)] // Must start with a number
+        [TestCase("Merge branch 'release-0.2.0'", true, "0.2.0")]
+        [TestCase("Merge branch 'hotfix-4.6.6' into support-4.6", true, "4.6.6")]
+        [TestCase("Merge branch 'hotfix-10.10.50'", true, "10.10.50")]
+        [TestCase("Merge branch 'hotfix-0.1.5'", true, "0.1.5")]
+        [TestCase("Merge branch 'hotfix-0.1.5'\n\nRelates to: TicketId", true, "0.1.5")]
+        [TestCase("Merge branch 'alpha-0.1.5'", true, "0.1.5")]
+        [TestCase("Merge pull request #165 from Particular/release-1.0.0", true, "1.0.0")]
+        [TestCase("Merge pull request #95 from Particular/issue-94", false, null)]
+        [TestCase("Merge pull request #165 in Particular/release-1.0.0", true, "1.0.0")]
+        [TestCase("Merge pull request #95 in Particular/issue-94", true, null)]
+        [TestCase("Merge pull request #95 in Particular/issue-94", false, null)]
+        [TestCase("Merge pull request #64 from arledesma/feature-VS2013_3rd_party_test_framework_support", true, null)]
+        [TestCase("Finish Release-0.12.0", true, "0.12.0")] //Support Syntevo SmartGit/Hg's Gitflow merge commit messages for finishing a 'Release' branch
+        [TestCase("Finish 0.14.1", true, "0.14.1")] //Support Syntevo SmartGit/Hg's Gitflow merge commit messages for finishing a 'Hotfix' branch
+        public void AssertMergeMessage(string message, bool isMergeCommit, string expectedVersion)
+        {
+            var parents = GetParents(isMergeCommit);
+            AssertMergeMessage(message, expectedVersion, parents);
+            AssertMergeMessage(message + " ", expectedVersion, parents);
+            AssertMergeMessage(message + "\r ", expectedVersion, parents);
+            AssertMergeMessage(message + "\r", expectedVersion, parents);
+            AssertMergeMessage(message + "\r\n", expectedVersion, parents);
+            AssertMergeMessage(message + "\r\n ", expectedVersion, parents);
+            AssertMergeMessage(message + "\n", expectedVersion, parents);
+            AssertMergeMessage(message + "\n ", expectedVersion, parents);
+        }
+
+        static void AssertMergeMessage(string message, string expectedVersion, List<Commit> parents)
+        {
+            var commit = new MockCommit
+            {
+                MessageEx = message,
+                ParentsEx = parents
+            };
+
+            var context = new GitVersionContextBuilder()
+                .WithRepository(new MockRepository
+                {
+                    Head = new MockBranch("master") { commit }
+                })
+                .Build();
+            var sut = new MergeMessageBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersion(context);
+
+            if (expectedVersion == null)
+            {
+                baseVersion.ShouldBe(null);
+            }
+            else
+            {
+                baseVersion.SemanticVersion.ToString().ShouldBe(expectedVersion);
+            }
+        }
+
+        static List<Commit> GetParents(bool isMergeCommit)
+        {
+            if (isMergeCommit)
+            {
+                return new List<Commit>
+            {
+                null,
+                null
+            };
+            }
+            return new List<Commit>
+        {
+            null
+        };
+        }
+    }
+}

--- a/GitVersionCore.Tests/VersionCalculation/Strategies/VersionInBranchBaseVersionStrategyTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/VersionInBranchBaseVersionStrategyTests.cs
@@ -1,0 +1,34 @@
+﻿namespace GitVersionCore.Tests.VersionCalculation.Strategies
+{
+    using GitVersion.VersionCalculation.BaseVersionCalculators;
+    using NUnit.Framework;
+    using Shouldly;
+
+    [TestFixture]
+    public class VersionInBranchBaseVersionStrategyTests
+    {
+        [Test]
+        [TestCase("release-2.0.0", "2.0.0")]
+        [TestCase("release/2.0.0", "2.0.0")]
+        [TestCase("hotfix-2.0.0", "2.0.0")]
+        [TestCase("hotfix/2.0.0", "2.0.0")]
+        [TestCase("hotfix/2.0.0", "2.0.0")]
+        [TestCase("feature/JIRA-123", null)]
+        public void CanTakeVersionFromBranchName(string branchName, string expectedBaseVersion)
+        {
+            var context = new GitVersionContextBuilder()
+                .WithBranch(branchName)
+                .AddCommit()
+                .Build();
+
+            var sut = new VersionInBranchBaseVersionStrategy();
+
+            var baseVersion = sut.GetVersion(context);
+
+            if (expectedBaseVersion == null)
+                baseVersion.ShouldBe(null);
+            else
+                baseVersion.SemanticVersion.ToString().ShouldBe(expectedBaseVersion);
+        }
+    }
+}

--- a/GitVersionCore.Tests/VersionCalculation/TestBaseVersionCalculator.cs
+++ b/GitVersionCore.Tests/VersionCalculation/TestBaseVersionCalculator.cs
@@ -1,5 +1,6 @@
 namespace GitVersionCore.Tests.VersionCalculation
 {
+    using System;
     using GitVersion;
     using GitVersion.VersionCalculation;
     using GitVersion.VersionCalculation.BaseVersionCalculators;
@@ -8,16 +9,18 @@ namespace GitVersionCore.Tests.VersionCalculation
     {
         readonly SemanticVersion semanticVersion;
         bool shouldIncrement;
+        DateTimeOffset? when;
 
-        public TestBaseVersionCalculator(bool shouldIncrement, SemanticVersion semanticVersion)
+        public TestBaseVersionCalculator(bool shouldIncrement, SemanticVersion semanticVersion, DateTimeOffset? when)
         {
             this.semanticVersion = semanticVersion;
+            this.when = when;
             this.shouldIncrement = shouldIncrement;
         }
 
         public BaseVersion GetBaseVersion(GitVersionContext context)
         {
-            return new BaseVersion(shouldIncrement, semanticVersion);
+            return new BaseVersion(shouldIncrement, semanticVersion, when);
         }
     }
 }

--- a/GitVersionCore.Tests/VersionCalculation/TestBaseVersionCalculator.cs
+++ b/GitVersionCore.Tests/VersionCalculation/TestBaseVersionCalculator.cs
@@ -1,0 +1,23 @@
+namespace GitVersionCore.Tests.VersionCalculation
+{
+    using GitVersion;
+    using GitVersion.VersionCalculation;
+    using GitVersion.VersionCalculation.BaseVersionCalculators;
+
+    public class TestBaseVersionCalculator : IBaseVersionCalculator
+    {
+        readonly SemanticVersion semanticVersion;
+        bool shouldIncrement;
+
+        public TestBaseVersionCalculator(bool shouldIncrement, SemanticVersion semanticVersion)
+        {
+            this.semanticVersion = semanticVersion;
+            this.shouldIncrement = shouldIncrement;
+        }
+
+        public BaseVersion GetBaseVersion(GitVersionContext context)
+        {
+            return new BaseVersion(shouldIncrement, semanticVersion);
+        }
+    }
+}

--- a/GitVersionCore.Tests/VersionCalculation/TestBaseVersionCalculator.cs
+++ b/GitVersionCore.Tests/VersionCalculation/TestBaseVersionCalculator.cs
@@ -1,26 +1,26 @@
 namespace GitVersionCore.Tests.VersionCalculation
 {
-    using System;
     using GitVersion;
     using GitVersion.VersionCalculation;
     using GitVersion.VersionCalculation.BaseVersionCalculators;
+    using LibGit2Sharp;
 
     public class TestBaseVersionCalculator : IBaseVersionCalculator
     {
         readonly SemanticVersion semanticVersion;
         bool shouldIncrement;
-        DateTimeOffset? when;
+        Commit source;
 
-        public TestBaseVersionCalculator(bool shouldIncrement, SemanticVersion semanticVersion, DateTimeOffset? when)
+        public TestBaseVersionCalculator(bool shouldIncrement, SemanticVersion semanticVersion, Commit source)
         {
             this.semanticVersion = semanticVersion;
-            this.when = when;
+            this.source = source;
             this.shouldIncrement = shouldIncrement;
         }
 
         public BaseVersion GetBaseVersion(GitVersionContext context)
         {
-            return new BaseVersion(shouldIncrement, semanticVersion, when);
+            return new BaseVersion(shouldIncrement, semanticVersion, source);
         }
     }
 }

--- a/GitVersionCore.Tests/VersionCalculation/TestMetaDataCalculator.cs
+++ b/GitVersionCore.Tests/VersionCalculation/TestMetaDataCalculator.cs
@@ -1,8 +1,8 @@
 ﻿namespace GitVersionCore.Tests.VersionCalculation
 {
-    using System;
     using GitVersion;
     using GitVersion.VersionCalculation;
+    using LibGit2Sharp;
 
     public class TestMetaDataCalculator : IMetaDataCalculator
     {
@@ -13,7 +13,7 @@
             this.metaData = metaData;
         }
 
-        public SemanticVersionBuildMetaData Create(DateTimeOffset? baseVersionWhenFrom, GitVersionContext context)
+        public SemanticVersionBuildMetaData Create(Commit baseVersionSource, GitVersionContext context)
         {
             return metaData;
         }

--- a/GitVersionCore.Tests/VersionCalculation/TestMetaDataCalculator.cs
+++ b/GitVersionCore.Tests/VersionCalculation/TestMetaDataCalculator.cs
@@ -1,0 +1,21 @@
+﻿namespace GitVersionCore.Tests.VersionCalculation
+{
+    using System;
+    using GitVersion;
+    using GitVersion.VersionCalculation;
+
+    public class TestMetaDataCalculator : IMetaDataCalculator
+    {
+        SemanticVersionBuildMetaData metaData;
+
+        public TestMetaDataCalculator(SemanticVersionBuildMetaData metaData)
+        {
+            this.metaData = metaData;
+        }
+
+        public SemanticVersionBuildMetaData Create(DateTimeOffset? baseVersionWhenFrom, GitVersionContext context)
+        {
+            return metaData;
+        }
+    }
+}

--- a/GitVersionCore/Configuration/BranchConfig.cs
+++ b/GitVersionCore/Configuration/BranchConfig.cs
@@ -9,5 +9,8 @@
 
         [YamlAlias("tag")]
         public string Tag { get; set; }
+
+        [YamlAlias("increment")]
+        public IncrementStrategy? Increment { get; set; }
     }
 }

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -18,6 +18,7 @@
             Branches["develop"] = new BranchConfig
             {
                 Tag = "unstable",
+                Increment = IncrementStrategy.Minor,
                 VersioningMode = GitVersion.VersioningMode.ContinuousDeployment
             };
         }

--- a/GitVersionCore/Configuration/IncrementStrategy.cs
+++ b/GitVersionCore/Configuration/IncrementStrategy.cs
@@ -1,0 +1,10 @@
+﻿namespace GitVersion
+{
+    public enum IncrementStrategy
+    {
+        None,
+        Major,
+        Minor,
+        Patch
+    }
+}

--- a/GitVersionCore/EffectiveConfiguration.cs
+++ b/GitVersionCore/EffectiveConfiguration.cs
@@ -5,13 +5,14 @@
     /// </summary>
     public class EffectiveConfiguration
     {
-        public EffectiveConfiguration(AssemblyVersioningScheme assemblyVersioningScheme, VersioningMode versioningMode, string gitTagPrefix, string tag, string nextVersion)
+        public EffectiveConfiguration(AssemblyVersioningScheme assemblyVersioningScheme, VersioningMode versioningMode, string gitTagPrefix, string tag, string nextVersion, IncrementStrategy increment)
         {
             AssemblyVersioningScheme = assemblyVersioningScheme;
             VersioningMode = versioningMode;
             GitTagPrefix = gitTagPrefix;
             Tag = tag;
             NextVersion = nextVersion;
+            Increment = increment;
         }
 
         public VersioningMode VersioningMode { get; private set; }
@@ -29,5 +30,6 @@
         public string Tag { get; private set; }
 
         public string NextVersion { get; private set; }
+        public IncrementStrategy Increment { get; private set; }
     }
 }

--- a/GitVersionCore/GitVersionContext.cs
+++ b/GitVersionCore/GitVersionContext.cs
@@ -88,8 +88,9 @@
             var versioningMode = currentBranchConfig.VersioningMode ?? configuration.VersioningMode ?? VersioningMode.ContinuousDelivery;
             var tag = currentBranchConfig.Tag;
             var nextVersion = configuration.NextVersion;
+            var incrementStrategy = currentBranchConfig.Increment ?? IncrementStrategy.Patch;
 
-            Configuration = new EffectiveConfiguration(configuration.AssemblyVersioningScheme, versioningMode, configuration.TagPrefix, tag, nextVersion);
+            Configuration = new EffectiveConfiguration(configuration.AssemblyVersioningScheme, versioningMode, configuration.TagPrefix, tag, nextVersion, incrementStrategy);
         }
 
         BranchConfig GetBranchConfiguration(KeyValuePair<string, BranchConfig>[] matchingBranches)

--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -95,6 +95,8 @@
     <Compile Include="VersionCalculation\BaseVersionCalculators\MergeMessageBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\IBaseVersionCalculator.cs" />
+    <Compile Include="VersionCalculation\IMetaDataCalculator.cs" />
+    <Compile Include="VersionCalculation\MetaDataCalculator.cs" />
     <Compile Include="VersionCalculation\NewNextVersionCalculator.cs" />
     <Compile Include="VersioningModes\ContinuousDeliveryMode.cs" />
     <Compile Include="VersioningModes\ContinuousDeploymentMode.cs" />

--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Configuration\Config.cs" />
     <Compile Include="Configuration\ConfigReader.cs" />
     <Compile Include="Configuration\ConfigurationProvider.cs" />
+    <Compile Include="Configuration\IncrementStrategy.cs" />
     <Compile Include="Configuration\LegacyConfig.cs" />
     <Compile Include="Configuration\LegacyConfigNotifier.cs" />
     <Compile Include="Configuration\OldConfigurationException.cs" />
@@ -93,6 +94,8 @@
     <Compile Include="VersionCalculation\BaseVersionCalculators\LastTagBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\MergeMessageBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionStrategy.cs" />
+    <Compile Include="VersionCalculation\IBaseVersionCalculator.cs" />
+    <Compile Include="VersionCalculation\NewNextVersionCalculator.cs" />
     <Compile Include="VersioningModes\ContinuousDeliveryMode.cs" />
     <Compile Include="VersioningModes\ContinuousDeploymentMode.cs" />
     <Compile Include="VersioningModes\VersioningMode.cs" />

--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -90,6 +90,7 @@
     <Compile Include="VersionCalculation\BaseVersionCalculator.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\BaseVersion.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\ConfigNextVersionBaseVersionStrategy.cs" />
+    <Compile Include="VersionCalculation\BaseVersionCalculators\LastTagBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\MergeMessageBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionStrategy.cs" />
     <Compile Include="VersioningModes\ContinuousDeliveryMode.cs" />

--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -90,6 +90,7 @@
     <Compile Include="VersionCalculation\BaseVersionCalculator.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\BaseVersion.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\ConfigNextVersionBaseVersionStrategy.cs" />
+    <Compile Include="VersionCalculation\BaseVersionCalculators\MergeMessageBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionStrategy.cs" />
     <Compile Include="VersioningModes\ContinuousDeliveryMode.cs" />
     <Compile Include="VersioningModes\ContinuousDeploymentMode.cs" />

--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -93,6 +93,7 @@
     <Compile Include="VersionCalculation\BaseVersionCalculators\ConfigNextVersionBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\LastTagBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\MergeMessageBaseVersionStrategy.cs" />
+    <Compile Include="VersionCalculation\BaseVersionCalculators\VersionInBranchBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\IBaseVersionCalculator.cs" />
     <Compile Include="VersionCalculation\IMetaDataCalculator.cs" />

--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -87,6 +87,10 @@
     <Compile Include="OutputVariables\CommitsAsFourthVersionPartFormatter.cs" />
     <Compile Include="OutputVariables\VersionVariables.cs" />
     <Compile Include="SemanticVersionExtensions.cs" />
+    <Compile Include="VersionCalculation\BaseVersionCalculator.cs" />
+    <Compile Include="VersionCalculation\BaseVersionCalculators\BaseVersion.cs" />
+    <Compile Include="VersionCalculation\BaseVersionCalculators\ConfigNextVersionBaseVersionStrategy.cs" />
+    <Compile Include="VersionCalculation\BaseVersionStrategy.cs" />
     <Compile Include="VersioningModes\ContinuousDeliveryMode.cs" />
     <Compile Include="VersioningModes\ContinuousDeploymentMode.cs" />
     <Compile Include="VersioningModes\VersioningMode.cs" />
@@ -144,6 +148,7 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/GitVersionCore/GitVersionFinder.cs
+++ b/GitVersionCore/GitVersionFinder.cs
@@ -10,6 +10,8 @@ namespace GitVersion
             Logger.WriteInfo("Running against branch: " + context.CurrentBranch.Name);
             EnsureMainTopologyConstraints(context);
 
+            //return new NewNextVersionCalculator().FindVersion(context);
+
             if (ShouldGitHubFlowVersioningSchemeApply(context.Repository))
             {
                 Logger.WriteInfo("GitHubFlow version strategy will be used");

--- a/GitVersionCore/MergeMessageParser.cs
+++ b/GitVersionCore/MergeMessageParser.cs
@@ -6,14 +6,14 @@ namespace GitVersion
 
     static class MergeMessageParser
     {
-        public static bool TryParse(Commit mergeCommit, EffectiveConfiguration configuration, out SemanticVersion shortVersion)
+        public static bool TryParse(Commit mergeCommit, EffectiveConfiguration configuration, out SemanticVersion semanticVersion)
         {
             string versionPart;
             if (Inner(mergeCommit, out versionPart))
             {
-                return SemanticVersion.TryParse(versionPart, configuration.GitTagPrefix, out shortVersion);
+                return SemanticVersion.TryParse(versionPart, configuration.GitTagPrefix, out semanticVersion);
             }
-            shortVersion = null;
+            semanticVersion = null;
             return false;
         }
 

--- a/GitVersionCore/SemanticVersion.cs
+++ b/GitVersionCore/SemanticVersion.cs
@@ -15,8 +15,11 @@ namespace GitVersion
         public SemanticVersionPreReleaseTag PreReleaseTag;
         public SemanticVersionBuildMetaData BuildMetaData;
 
-        public SemanticVersion()
+        public SemanticVersion(int major = 0, int minor = 0, int patch = 0)
         {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
             PreReleaseTag = new SemanticVersionPreReleaseTag();
             BuildMetaData = new SemanticVersionBuildMetaData();
         }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -17,7 +17,15 @@
             return strategies
                 .Select(s => s.GetVersion(context))
                 .Where(v => v != null)
-                .Aggregate((v1, v2) => v1.SemanticVersion > v2.SemanticVersion ? v1 : v2);
+                .Aggregate((v1, v2) =>
+                {
+                    if (v1.SemanticVersion > v2.SemanticVersion)
+                    {
+                        return new BaseVersion(v1.ShouldIncrement, v1.SemanticVersion, v1.BaseVersionWhenFrom ?? v2.BaseVersionWhenFrom);
+                    }
+
+                    return new BaseVersion(v2.ShouldIncrement, v2.SemanticVersion, v2.BaseVersionWhenFrom ?? v1.BaseVersionWhenFrom);
+                });
         }
     }
 }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -21,10 +21,10 @@
                 {
                     if (v1.SemanticVersion > v2.SemanticVersion)
                     {
-                        return new BaseVersion(v1.ShouldIncrement, v1.SemanticVersion, v1.BaseVersionWhenFrom ?? v2.BaseVersionWhenFrom);
+                        return new BaseVersion(v1.ShouldIncrement, v1.SemanticVersion, v1.BaseVersionSource ?? v2.BaseVersionSource);
                     }
 
-                    return new BaseVersion(v2.ShouldIncrement, v2.SemanticVersion, v2.BaseVersionWhenFrom ?? v1.BaseVersionWhenFrom);
+                    return new BaseVersion(v2.ShouldIncrement, v2.SemanticVersion, v2.BaseVersionSource ?? v1.BaseVersionSource);
                 });
         }
     }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -1,0 +1,23 @@
+﻿namespace GitVersion.VersionCalculation
+{
+    using System.Linq;
+    using GitVersion.VersionCalculation.BaseVersionCalculators;
+
+    public class BaseVersionCalculator
+    {
+        readonly BaseVersionStrategy[] strategies;
+
+        public BaseVersionCalculator(params BaseVersionStrategy[] strategies)
+        {
+            this.strategies = strategies;
+        }
+
+        public BaseVersion GetBaseVersion(GitVersionContext context)
+        {
+            return strategies
+                .Select(s => s.GetVersion(context))
+                .Where(v => v != null)
+                .Aggregate((v1, v2) => v1.SemanticVersion > v2.SemanticVersion ? v1 : v2);
+        }
+    }
+}

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -1,9 +1,9 @@
 ﻿namespace GitVersion.VersionCalculation
 {
     using System.Linq;
-    using GitVersion.VersionCalculation.BaseVersionCalculators;
+    using BaseVersionCalculators;
 
-    public class BaseVersionCalculator
+    public class BaseVersionCalculator : IBaseVersionCalculator
     {
         readonly BaseVersionStrategy[] strategies;
 

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/BaseVersion.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/BaseVersion.cs
@@ -1,25 +1,20 @@
 ﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
 {
-    using System;
+    using LibGit2Sharp;
 
     public class BaseVersion
     {
-        public BaseVersion(bool shouldIncrement, SemanticVersion semanticVersion, DateTimeOffset? baseVersionWhenFrom)
+        public BaseVersion(bool shouldIncrement, SemanticVersion semanticVersion, Commit baseVersionSource)
         {
             ShouldIncrement = shouldIncrement;
             SemanticVersion = semanticVersion;
-            BaseVersionWhenFrom = baseVersionWhenFrom;
+            BaseVersionSource = baseVersionSource;
         }
 
         public bool ShouldIncrement { get; private set; }
 
         public SemanticVersion SemanticVersion { get; private set; }
 
-        /// <summary>
-        /// Can be null even if the base version has a version
-        /// 
-        /// This happens when the base version doesn't have a time it came from
-        /// </summary>
-        public DateTimeOffset? BaseVersionWhenFrom { get; private set; }
+        public Commit BaseVersionSource { get; private set; }
     }
 }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/BaseVersion.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/BaseVersion.cs
@@ -1,15 +1,25 @@
 ﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
 {
+    using System;
+
     public class BaseVersion
     {
-        public BaseVersion(bool shouldIncrement, SemanticVersion semanticVersion)
+        public BaseVersion(bool shouldIncrement, SemanticVersion semanticVersion, DateTimeOffset? baseVersionWhenFrom)
         {
             ShouldIncrement = shouldIncrement;
             SemanticVersion = semanticVersion;
+            BaseVersionWhenFrom = baseVersionWhenFrom;
         }
 
         public bool ShouldIncrement { get; private set; }
 
         public SemanticVersion SemanticVersion { get; private set; }
+
+        /// <summary>
+        /// Can be null even if the base version has a version
+        /// 
+        /// This happens when the base version doesn't have a time it came from
+        /// </summary>
+        public DateTimeOffset? BaseVersionWhenFrom { get; private set; }
     }
 }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/BaseVersion.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/BaseVersion.cs
@@ -1,0 +1,15 @@
+﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
+{
+    public class BaseVersion
+    {
+        public BaseVersion(bool shouldIncrement, SemanticVersion semanticVersion)
+        {
+            ShouldIncrement = shouldIncrement;
+            SemanticVersion = semanticVersion;
+        }
+
+        public bool ShouldIncrement { get; private set; }
+
+        public SemanticVersion SemanticVersion { get; private set; }
+    }
+}

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/ConfigNextVersionBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/ConfigNextVersionBaseVersionStrategy.cs
@@ -6,7 +6,7 @@
         {
             if (string.IsNullOrEmpty(context.Configuration.NextVersion))
                 return null;
-            return new BaseVersion(false, SemanticVersion.Parse(context.Configuration.NextVersion, context.Configuration.GitTagPrefix));
+            return new BaseVersion(false, SemanticVersion.Parse(context.Configuration.NextVersion, context.Configuration.GitTagPrefix), null);
         }
     }
 }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/ConfigNextVersionBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/ConfigNextVersionBaseVersionStrategy.cs
@@ -1,0 +1,12 @@
+﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
+{
+    public class ConfigNextVersionBaseVersionStrategy : BaseVersionStrategy
+    {
+        public override BaseVersion GetVersion(GitVersionContext context)
+        {
+            if (string.IsNullOrEmpty(context.Configuration.NextVersion))
+                return null;
+            return new BaseVersion(false, SemanticVersion.Parse(context.Configuration.NextVersion, context.Configuration.GitTagPrefix));
+        }
+    }
+}

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
@@ -1,0 +1,14 @@
+﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
+{
+    public class LastTagBaseVersionStrategy : BaseVersionStrategy
+    {
+        public override BaseVersion GetVersion(GitVersionContext context)
+        {
+            VersionTaggedCommit version;
+            if (new LastTaggedReleaseFinder(context).GetVersion(out version))
+                return new BaseVersion(true, version.SemVer);
+
+            return null;
+        }
+    }
+}

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
@@ -6,7 +6,7 @@
         {
             VersionTaggedCommit version;
             if (new LastTaggedReleaseFinder(context).GetVersion(out version))
-                return new BaseVersion(true, version.SemVer, version.Commit.When());
+                return new BaseVersion(true, version.SemVer, version.Commit);
 
             return null;
         }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
@@ -6,7 +6,7 @@
         {
             VersionTaggedCommit version;
             if (new LastTaggedReleaseFinder(context).GetVersion(out version))
-                return new BaseVersion(true, version.SemVer);
+                return new BaseVersion(true, version.SemVer, version.Commit.When());
 
             return null;
         }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
@@ -6,7 +6,10 @@
         {
             VersionTaggedCommit version;
             if (new LastTaggedReleaseFinder(context).GetVersion(out version))
-                return new BaseVersion(true, version.SemVer, version.Commit);
+            {
+                var shouldIncrement = version.Commit != context.CurrentCommit;
+                return new BaseVersion(shouldIncrement, version.SemVer, version.Commit);
+            }
 
             return null;
         }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -9,7 +9,7 @@
                 SemanticVersion semanticVersion;
                 // TODO when this approach works, inline the other class into here
                 if (MergeMessageParser.TryParse(context.CurrentCommit, context.Configuration, out semanticVersion))
-                    return new BaseVersion(true, semanticVersion, commit.When());
+                    return new BaseVersion(true, semanticVersion, commit);
             }
             return null;
         }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -1,0 +1,15 @@
+﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
+{
+    public class MergeMessageBaseVersionStrategy : BaseVersionStrategy
+    {
+        public override BaseVersion GetVersion(GitVersionContext context)
+        {
+            // TODO when this approach works, inline the other class into here
+            SemanticVersion semanticVersion;
+            if (MergeMessageParser.TryParse(context.CurrentCommit, context.Configuration, out semanticVersion))
+                return new BaseVersion(true, semanticVersion);
+
+            return null;
+        }
+    }
+}

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -4,11 +4,13 @@
     {
         public override BaseVersion GetVersion(GitVersionContext context)
         {
-            // TODO when this approach works, inline the other class into here
-            SemanticVersion semanticVersion;
-            if (MergeMessageParser.TryParse(context.CurrentCommit, context.Configuration, out semanticVersion))
-                return new BaseVersion(true, semanticVersion);
-
+            foreach (var commit in context.CurrentBranch.CommitsPriorToThan(context.CurrentCommit.When()))
+            {
+                SemanticVersion semanticVersion;
+                // TODO when this approach works, inline the other class into here
+                if (MergeMessageParser.TryParse(context.CurrentCommit, context.Configuration, out semanticVersion))
+                    return new BaseVersion(true, semanticVersion, commit.When());
+            }
             return null;
         }
     }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchBaseVersionStrategy.cs
@@ -1,0 +1,35 @@
+﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
+{
+    using System;
+    using System.Linq;
+
+    public class VersionInBranchBaseVersionStrategy : BaseVersionStrategy
+    {
+        public override BaseVersion GetVersion(GitVersionContext context)
+        {
+            var versionInBranch = GetVersionInBranch(context);
+            if (versionInBranch != null)
+            {
+                var firstCommitOfBranch = context.CurrentBranch.Commits.Last();
+                return new BaseVersion(false, versionInBranch.Item2, firstCommitOfBranch);
+            }
+
+            return null;
+        }
+
+        Tuple<string, SemanticVersion> GetVersionInBranch(GitVersionContext context)
+        {
+            var branchParts = context.CurrentBranch.Name.Split('/', '-');
+            foreach (var part in branchParts)
+            {
+                SemanticVersion semanticVersion;
+                if (SemanticVersion.TryParse(part, context.Configuration.GitTagPrefix, out semanticVersion))
+                {
+                    return Tuple.Create(part, semanticVersion);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/GitVersionCore/VersionCalculation/BaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionStrategy.cs
@@ -1,0 +1,9 @@
+﻿namespace GitVersion.VersionCalculation
+{
+    using GitVersion.VersionCalculation.BaseVersionCalculators;
+
+    public abstract class BaseVersionStrategy
+    {
+        public abstract BaseVersion GetVersion(GitVersionContext context);
+    }
+}

--- a/GitVersionCore/VersionCalculation/IBaseVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/IBaseVersionCalculator.cs
@@ -1,0 +1,9 @@
+﻿namespace GitVersion.VersionCalculation
+{
+    using GitVersion.VersionCalculation.BaseVersionCalculators;
+
+    public interface IBaseVersionCalculator
+    {
+        BaseVersion GetBaseVersion(GitVersionContext context);
+    }
+}

--- a/GitVersionCore/VersionCalculation/IMetaDataCalculator.cs
+++ b/GitVersionCore/VersionCalculation/IMetaDataCalculator.cs
@@ -1,0 +1,9 @@
+﻿namespace GitVersion.VersionCalculation
+{
+    using System;
+
+    public interface IMetaDataCalculator
+    {
+        SemanticVersionBuildMetaData Create(DateTimeOffset? baseVersionWhenFrom, GitVersionContext context);
+    }
+}

--- a/GitVersionCore/VersionCalculation/IMetaDataCalculator.cs
+++ b/GitVersionCore/VersionCalculation/IMetaDataCalculator.cs
@@ -1,9 +1,9 @@
 ﻿namespace GitVersion.VersionCalculation
 {
-    using System;
+    using LibGit2Sharp;
 
     public interface IMetaDataCalculator
     {
-        SemanticVersionBuildMetaData Create(DateTimeOffset? baseVersionWhenFrom, GitVersionContext context);
+        SemanticVersionBuildMetaData Create(Commit baseVersionSource, GitVersionContext context);
     }
 }

--- a/GitVersionCore/VersionCalculation/MetaDataCalculator.cs
+++ b/GitVersionCore/VersionCalculation/MetaDataCalculator.cs
@@ -1,0 +1,25 @@
+﻿namespace GitVersion.VersionCalculation
+{
+    using System;
+    using System.Linq;
+    using LibGit2Sharp;
+
+    public class MetaDataCalculator : IMetaDataCalculator
+    {
+        public SemanticVersionBuildMetaData Create(DateTimeOffset? baseVersionWhenFrom, GitVersionContext context)
+        {
+            var qf = new CommitFilter
+            {
+                Since = baseVersionWhenFrom,
+                Until = context.CurrentCommit,
+                SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Time
+            };
+
+            return new SemanticVersionBuildMetaData(
+                context.Repository.Commits.QueryBy(qf).Count(),
+                context.CurrentBranch.Name,
+                context.CurrentCommit.Sha,
+                context.CurrentCommit.When());
+        }
+    }
+}

--- a/GitVersionCore/VersionCalculation/MetaDataCalculator.cs
+++ b/GitVersionCore/VersionCalculation/MetaDataCalculator.cs
@@ -14,8 +14,10 @@
                 SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Time
             };
 
+            var commitsSinceTag = context.Repository.Commits.QueryBy(qf).Count();
+
             return new SemanticVersionBuildMetaData(
-                context.Repository.Commits.QueryBy(qf).Count(),
+                commitsSinceTag,
                 context.CurrentBranch.Name,
                 context.CurrentCommit.Sha,
                 context.CurrentCommit.When());

--- a/GitVersionCore/VersionCalculation/MetaDataCalculator.cs
+++ b/GitVersionCore/VersionCalculation/MetaDataCalculator.cs
@@ -1,16 +1,15 @@
 ﻿namespace GitVersion.VersionCalculation
 {
-    using System;
     using System.Linq;
     using LibGit2Sharp;
 
     public class MetaDataCalculator : IMetaDataCalculator
     {
-        public SemanticVersionBuildMetaData Create(DateTimeOffset? baseVersionWhenFrom, GitVersionContext context)
+        public SemanticVersionBuildMetaData Create(Commit baseVersionSource, GitVersionContext context)
         {
             var qf = new CommitFilter
             {
-                Since = baseVersionWhenFrom,
+                Since = baseVersionSource,
                 Until = context.CurrentCommit,
                 SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Time
             };

--- a/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
@@ -15,7 +15,8 @@
                 new BaseVersionCalculator(
                 new ConfigNextVersionBaseVersionStrategy(),
                 new LastTagBaseVersionStrategy(),
-                new MergeMessageBaseVersionStrategy());
+                new MergeMessageBaseVersionStrategy(),
+                new VersionInBranchBaseVersionStrategy());
         }
 
         public SemanticVersion FindVersion(GitVersionContext context)

--- a/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
@@ -6,9 +6,11 @@
     public class NewNextVersionCalculator
     {
         IBaseVersionCalculator baseVersionFinder;
+        IMetaDataCalculator metaDataCalculator;
 
-        public NewNextVersionCalculator(IBaseVersionCalculator baseVersionCalculator = null)
+        public NewNextVersionCalculator(IBaseVersionCalculator baseVersionCalculator = null, IMetaDataCalculator metaDataCalculator = null)
         {
+            this.metaDataCalculator = metaDataCalculator ?? new MetaDataCalculator();
             baseVersionFinder = baseVersionCalculator ??
                 new BaseVersionCalculator(
                 new ConfigNextVersionBaseVersionStrategy(),
@@ -21,6 +23,8 @@
             var baseVersion = baseVersionFinder.GetBaseVersion(context);
 
             if (baseVersion.ShouldIncrement) IncrementVersion(context, baseVersion);
+
+            baseVersion.SemanticVersion.BuildMetaData = metaDataCalculator.Create(baseVersion.BaseVersionWhenFrom, context);
 
             return baseVersion.SemanticVersion;
         }

--- a/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
@@ -57,8 +57,11 @@
             }
             else
             {
-                baseVersion.SemanticVersion.PreReleaseTag.Number = baseVersion.SemanticVersion.PreReleaseTag.Number ?? 0;
-                baseVersion.SemanticVersion.PreReleaseTag.Number++;
+                if (baseVersion.SemanticVersion.PreReleaseTag.Number != null)
+                {
+                    baseVersion.SemanticVersion.PreReleaseTag.Number = baseVersion.SemanticVersion.PreReleaseTag.Number;
+                    baseVersion.SemanticVersion.PreReleaseTag.Number++;
+                }
             }
         }
     }

--- a/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
@@ -1,0 +1,56 @@
+﻿namespace GitVersion.VersionCalculation
+{
+    using System;
+    using BaseVersionCalculators;
+
+    public class NewNextVersionCalculator
+    {
+        IBaseVersionCalculator baseVersionFinder;
+
+        public NewNextVersionCalculator(IBaseVersionCalculator baseVersionCalculator = null)
+        {
+            baseVersionFinder = baseVersionCalculator ??
+                new BaseVersionCalculator(
+                new ConfigNextVersionBaseVersionStrategy(),
+                new LastTagBaseVersionStrategy(),
+                new MergeMessageBaseVersionStrategy());
+        }
+
+        public SemanticVersion FindVersion(GitVersionContext context)
+        {
+            var baseVersion = baseVersionFinder.GetBaseVersion(context);
+
+            if (baseVersion.ShouldIncrement) IncrementVersion(context, baseVersion);
+
+            return baseVersion.SemanticVersion;
+        }
+
+        static void IncrementVersion(GitVersionContext context, BaseVersion baseVersion)
+        {
+            if (!baseVersion.SemanticVersion.PreReleaseTag.HasTag())
+            {
+                switch (context.Configuration.Increment)
+                {
+                    case IncrementStrategy.None:
+                        break;
+                    case IncrementStrategy.Major:
+                        baseVersion.SemanticVersion.Major++;
+                        break;
+                    case IncrementStrategy.Minor:
+                        baseVersion.SemanticVersion.Minor++;
+                        break;
+                    case IncrementStrategy.Patch:
+                        baseVersion.SemanticVersion.Patch++;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+            else
+            {
+                baseVersion.SemanticVersion.PreReleaseTag.Number = baseVersion.SemanticVersion.PreReleaseTag.Number ?? 0;
+                baseVersion.SemanticVersion.PreReleaseTag.Number++;
+            }
+        }
+    }
+}

--- a/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
@@ -24,7 +24,12 @@
 
             if (baseVersion.ShouldIncrement) IncrementVersion(context, baseVersion);
 
-            baseVersion.SemanticVersion.BuildMetaData = metaDataCalculator.Create(baseVersion.BaseVersionWhenFrom, context);
+            if (!baseVersion.SemanticVersion.PreReleaseTag.HasTag() && !string.IsNullOrEmpty(context.Configuration.Tag))
+            {
+                baseVersion.SemanticVersion.PreReleaseTag = new SemanticVersionPreReleaseTag(context.Configuration.Tag, 1);
+            }
+
+            baseVersion.SemanticVersion.BuildMetaData = metaDataCalculator.Create(baseVersion.BaseVersionSource, context);
 
             return baseVersion.SemanticVersion;
         }


### PR DESCRIPTION
Start of new internals which does not use any branch finders or know anything about branches.

Still a bunch of integration tests which need to be fixed when you switch over to use new stuff in `GitVersionFinder` (uncomment commented line)