### PR TITLE
Fixing tests

### DIFF
--- a/GitVersionCore.Tests/GitVersionCore.Tests.csproj
+++ b/GitVersionCore.Tests/GitVersionCore.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="GitDirFinderTests.cs" />
     <Compile Include="Fixtures\BaseGitFlowRepositoryFixture.cs" />
     <Compile Include="GitVersionContextTests.cs" />
+    <Compile Include="IntegrationTests\PullRequestScenarios.cs" />
     <Compile Include="IntegrationTests\RemoteRepositoryTests.cs" />
     <Compile Include="IntegrationTests\GitFlow\DevelopScenarios.cs" />
     <Compile Include="IntegrationTests\GitFlow\GitFlowFeatureBranchTests.cs" />

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/DevelopScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/DevelopScenarios.cs
@@ -12,8 +12,35 @@ public class DevelopScenarios
         {
             fixture.Repository.MakeATaggedCommit("1.0.0");
             fixture.Repository.CreateBranch("develop").Checkout();
-            // TODO Should actually be 1.0.0+0
-            fixture.AssertFullSemver("1.1.0-unstable.0+0");
+            fixture.AssertFullSemver("1.0.0+0");
+        }
+    }
+
+    [Test]
+    public void CanChangeDevelopTagViaConfig()
+    {
+        var config = new Config();
+        config.Branches["develop"].Tag = "alpha";
+        using (var fixture = new EmptyRepositoryFixture(config))
+        {
+            fixture.Repository.MakeATaggedCommit("1.0.0");
+            fixture.Repository.CreateBranch("develop").Checkout();
+            fixture.Repository.MakeACommit();
+            fixture.AssertFullSemver("1.1.0-alpha.1+1");
+        }
+    }
+
+    [Test]
+    public void CanClearDevelopTagViaConfig()
+    {
+        var config = new Config();
+        config.Branches["develop"].Tag = "";
+        using (var fixture = new EmptyRepositoryFixture(config))
+        {
+            fixture.Repository.MakeATaggedCommit("1.0.0");
+            fixture.Repository.CreateBranch("develop").Checkout();
+            fixture.Repository.MakeACommit();
+            fixture.AssertFullSemver("1.1.0+1");
         }
     }
 
@@ -45,19 +72,6 @@ public class DevelopScenarios
             fixture.AssertFullSemver("1.1.0-unstable.1+1");
         }
     }
-    
-    [Test]
-    public void CanChangeDevelopTagViaConfig()
-    {
-        var config = new Config();
-        config.Branches["develop"].Tag = "alpha";
-        using (var fixture = new EmptyRepositoryFixture(config))
-        {
-            fixture.Repository.MakeATaggedCommit("1.0.0");
-            fixture.Repository.CreateBranch("develop").Checkout();
-            fixture.AssertFullSemver("1.1.0-alpha.0+0");
-        }
-    }
 
     [Test]
     public void CanHandleContinuousDelivery()
@@ -69,20 +83,7 @@ public class DevelopScenarios
             fixture.Repository.MakeATaggedCommit("1.0.0");
             fixture.Repository.CreateBranch("develop").Checkout();
             fixture.Repository.MakeATaggedCommit("1.1.0-alpha7");
-            fixture.AssertFullSemver("1.1.0-alpha.7+1");
-        }
-    }
-    
-    [Test]
-    public void CanClearDevelopTagViaConfig()
-    {
-        var config = new Config();
-        config.Branches["develop"].Tag = "";
-        using (var fixture = new EmptyRepositoryFixture(config))
-        {
-            fixture.Repository.MakeATaggedCommit("1.0.0");
-            fixture.Repository.CreateBranch("develop").Checkout();
-            fixture.AssertFullSemver("1.1.0+0");
+            fixture.AssertFullSemver("1.1.0-alpha.7+0");
         }
     }
 

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/GitFlowFeatureBranchTests.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/GitFlowFeatureBranchTests.cs
@@ -17,7 +17,7 @@ public class GitFlowFeatureBranchTests
             fixture.Repository.Checkout("feature/JIRA-123");
             fixture.Repository.MakeCommits(5);
 
-            fixture.AssertFullSemver("1.1.0-JIRA-123+5");
+            fixture.AssertFullSemver("1.1.0-JIRA-123.1+5");
         }
     }    
 }

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/PatchScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/PatchScenarios.cs
@@ -13,13 +13,13 @@ public class PatchScenarios
             // create hotfix
             fixture.Repository.CreateBranch("hotfix-1.2.1").Checkout();
 
+            fixture.AssertFullSemver("1.2.1-beta.1+0");
+            fixture.Repository.MakeACommit();
             fixture.AssertFullSemver("1.2.1-beta.1+1");
-            fixture.Repository.MakeACommit();
-            fixture.AssertFullSemver("1.2.1-beta.1+2");
             fixture.Repository.ApplyTag("1.2.1-beta.1");
-            fixture.AssertFullSemver("1.2.1-beta.1+2");
+            fixture.AssertFullSemver("1.2.1-beta.1+0");
             fixture.Repository.MakeACommit();
-            fixture.AssertFullSemver("1.2.1-beta.2+3");
+            fixture.AssertFullSemver("1.2.1-beta.2+1");
 
             // Merge hotfix branch to master
             fixture.Repository.Checkout("master");

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/ReleaseBranchTests.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/ReleaseBranchTests.cs
@@ -16,7 +16,9 @@ public class GitFlowReleaseBranchTests
             fixture.Repository.CreateBranch("release-2.0.0");
             fixture.Repository.Checkout("release-2.0.0");
 
-            fixture.AssertFullSemver("2.0.0-beta.1+5");
+            fixture.AssertFullSemver("2.0.0-beta.1+0");
+            fixture.Repository.MakeCommits(2);
+            fixture.AssertFullSemver("2.0.0-beta.1+2");
         }
     }
 
@@ -33,26 +35,9 @@ public class GitFlowReleaseBranchTests
             fixture.Repository.CreateBranch("release-2.0.0");
             fixture.Repository.Checkout("release-2.0.0");
 
-            fixture.AssertFullSemver("2.0.0-rc.1+5");
-        }
-    }
-
-    [Test]
-    public void CanHandleContinuousDeployment()
-    {
-        var config = new Config
-                         {
-                             VersioningMode = VersioningMode.ContinuousDeployment
-                         };
-        using (var fixture = new EmptyRepositoryFixture(config))
-        {
-            fixture.Repository.MakeATaggedCommit("1.0.3");
-            fixture.Repository.CreateBranch("develop");
-            fixture.Repository.MakeCommits(5);
-            fixture.Repository.CreateBranch("release-2.0.0");
-            fixture.Repository.Checkout("release-2.0.0");
-
-            fixture.AssertFullSemver("2.0.0-beta.5+5");
+            fixture.AssertFullSemver("2.0.0-rc.1+0");
+            fixture.Repository.MakeCommits(2);
+            fixture.AssertFullSemver("2.0.0-rc.1+2");
         }
     }
 
@@ -67,7 +52,9 @@ public class GitFlowReleaseBranchTests
             fixture.Repository.CreateBranch("release-2.0.0-Final");
             fixture.Repository.Checkout("release-2.0.0-Final");
 
-            fixture.AssertFullSemver("2.0.0-beta.1+5");
+            fixture.AssertFullSemver("2.0.0-beta.1+0");
+            fixture.Repository.MakeCommits(2);
+            fixture.AssertFullSemver("2.0.0-beta.1+2");
         }
     }
 
@@ -85,13 +72,13 @@ public class GitFlowReleaseBranchTests
             fixture.Repository.Checkout("master");
             fixture.Repository.MergeNoFF("release-2.0.0", Constants.SignatureNow());
 
-            // TODO For GitHubFlow this is 2.0.0+6, why is it different
-            fixture.AssertFullSemver("2.0.0");
+            fixture.AssertFullSemver("2.0.0+0");
+            fixture.Repository.MakeCommits(2);
+            fixture.AssertFullSemver("2.0.0+2");
         }
     }
 
-    // TODO This test fails for GitFlow, it needs to be fixed (although in reality a support branch should be used)
-    [Test, Ignore]
+    [Test]
     public void WhenReleaseBranchIsMergedIntoMasterHighestVersionIsTakenWithIt()
     {
         using (var fixture = new EmptyRepositoryFixture(new Config()))
@@ -116,7 +103,7 @@ public class GitFlowReleaseBranchTests
             fixture.Repository.Checkout("develop");
             fixture.Repository.MergeNoFF("release-1.0.0", Constants.SignatureNow());
 
-            fixture.AssertFullSemver("2.0.0+11");
+            fixture.AssertFullSemver("2.0.0-unstable.1+5");
         }
     }
 }

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/SwitchingToGitFlowScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/SwitchingToGitFlowScenarios.cs
@@ -14,7 +14,7 @@ public class SwitchingToGitFlowScenarios
             fixture.Repository.MakeATaggedCommit("1.0.0.0");
             fixture.Repository.MakeCommits(2);
             fixture.Repository.CreateBranch("develop").Checkout();
-            fixture.AssertFullSemver("1.1.0-unstable.0+0");
+            fixture.AssertFullSemver("1.1.0-unstable.1+2");
         }
     }
 }

--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/WikiScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/WikiScenarios.cs
@@ -44,7 +44,8 @@ note over develop: 1.4.0.2-unstable
 
             // Branch to develop
             fixture.Repository.CreateBranch("develop").Checkout();
-            fixture.AssertFullSemver("1.3.0-unstable.0+0");
+            fixture.Repository.MakeACommit();
+            fixture.AssertFullSemver("1.3.0-unstable.1+1");
 
             // Open Pull Request
             fixture.Repository.CreateBranch("pull/2/merge").Checkout();

--- a/GitVersionCore.Tests/IntegrationTests/GitHubFlow/GitHubFlowFeatureBranchTests.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitHubFlow/GitHubFlowFeatureBranchTests.cs
@@ -15,7 +15,7 @@ public class GitHubFlowFeatureBranchTests
             fixture.Repository.Checkout("feature/JIRA-123");
             fixture.Repository.MakeCommits(5);
 
-            fixture.AssertFullSemver("1.0.1-JIRA-123+5");
+            fixture.AssertFullSemver("1.0.1-JIRA-123.1+5");
         }
     }
 
@@ -29,7 +29,7 @@ public class GitHubFlowFeatureBranchTests
             fixture.Repository.Checkout("feature-test");
             fixture.Repository.MakeCommits(5);
 
-            fixture.AssertFullSemver("1.0.1-feature-test+5");
+            fixture.AssertFullSemver("1.0.1-test.1+5");
         }
     }
 }

--- a/GitVersionCore.Tests/IntegrationTests/GitHubFlow/GitHubFlowSupportBranchScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitHubFlow/GitHubFlowSupportBranchScenarios.cs
@@ -37,16 +37,16 @@ public class GitHubFlowSupportBranchScenarios
             // Create 1.2.0 release
             fixture.Repository.Checkout("support/1.0.0");
             fixture.Repository.MergeNoFF("release/1.2.0");
-            fixture.AssertFullSemver("1.2.0+2");
+            fixture.AssertFullSemver("1.2.0+0");
             fixture.Repository.ApplyTag("1.2.0");
 
             // Create 1.2.1 hotfix
             fixture.Repository.CreateBranch("hotfix/1.2.1").Checkout();
             fixture.Repository.MakeACommit();
-            fixture.AssertFullSemver("1.2.1+1");
+            fixture.AssertFullSemver("1.2.1-beta.1+1");
             fixture.Repository.Checkout("support/1.0.0");
             fixture.Repository.MergeNoFF("hotfix/1.2.1");
-            fixture.AssertFullSemver("1.2.1+2");
+            fixture.AssertFullSemver("1.2.1+0");
         }
     }
 
@@ -69,7 +69,7 @@ public class GitHubFlowSupportBranchScenarios
             fixture.Repository.MakeACommit();
             fixture.Repository.MakeACommit();
 
-            fixture.AssertFullSemver("1.3.1+2");
+            fixture.AssertFullSemver("1.3.1+0");
         }
     }
 }

--- a/GitVersionCore.Tests/IntegrationTests/GitHubFlow/ReleaseBranchTests.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitHubFlow/ReleaseBranchTests.cs
@@ -15,7 +15,9 @@ public class ReleaseBranchTests
             fixture.Repository.CreateBranch("release-2.0.0");
             fixture.Repository.Checkout("release-2.0.0");
 
-            fixture.AssertFullSemver("2.0.0-beta.1+5");
+            fixture.AssertFullSemver("2.0.0-beta.1+0");
+            fixture.Repository.MakeCommits(2);
+            fixture.AssertFullSemver("2.0.0-beta.1+2");
         }
     }
 
@@ -31,7 +33,9 @@ public class ReleaseBranchTests
             fixture.Repository.CreateBranch("release-2.0.0");
             fixture.Repository.Checkout("release-2.0.0");
 
-            fixture.AssertFullSemver("2.0.0-rc.1+5");
+            fixture.AssertFullSemver("2.0.0-rc.1+0");
+            fixture.Repository.MakeCommits(2);
+            fixture.AssertFullSemver("2.0.0-rc.1+2");
         }
     }
 
@@ -48,7 +52,7 @@ public class ReleaseBranchTests
             fixture.Repository.Checkout("master");
             fixture.Repository.MergeNoFF("release-2.0.0", Constants.SignatureNow());
 
-            fixture.AssertFullSemver("2.0.0+6");
+            fixture.AssertFullSemver("2.0.0+0");
         }
     }
     [Test]
@@ -71,7 +75,7 @@ public class ReleaseBranchTests
             fixture.Repository.Checkout("master");
             fixture.Repository.MergeNoFF("release-1.0.0", Constants.SignatureNow());
 
-            fixture.AssertFullSemver("2.0.0+11");
+            fixture.AssertFullSemver("2.0.0+5");
         }
     }
 

--- a/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -48,4 +48,52 @@ public class PullRequestScenarios
             fixture.AssertFullSemver("0.2.0-PullRequest.1+3");
         }
     }
+
+    [Test]
+    public void CanCalculatePullRequestChangesFromRemoteRepo()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            fixture.Repository.MakeATaggedCommit("0.1.0");
+            fixture.Repository.CreateBranch("feature/Foo").Checkout();
+            fixture.Repository.MakeACommit();
+
+            fixture.Repository.Checkout("master");
+            fixture.Repository.MergeNoFF("feature/Foo");
+            fixture.Repository.CreateBranch("pull/2/merge").Checkout();
+            fixture.Repository.Checkout("master");
+            fixture.Repository.Reset(ResetMode.Hard, "HEAD~1");
+            fixture.Repository.Checkout("pull/2/merge");
+            // If we delete the branch, it is effectively the same as remote PR
+            fixture.Repository.Branches.Remove("feature/Foo");
+
+            fixture.DumpGraph();
+            fixture.AssertFullSemver("0.1.1-PullRequest.1+2");
+        }
+    }
+
+    [Test]
+    public void CanCalculatePullRequestChangesInheritingConfigFromRemoteRepo()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            fixture.Repository.MakeATaggedCommit("0.1.0");
+            fixture.Repository.CreateBranch("develop").Checkout();
+            fixture.Repository.MakeACommit();
+            fixture.Repository.CreateBranch("feature/Foo").Checkout();
+            fixture.Repository.MakeACommit();
+
+            fixture.Repository.Checkout("develop");
+            fixture.Repository.MergeNoFF("feature/Foo");
+            fixture.Repository.CreateBranch("pull/2/merge").Checkout();
+            fixture.Repository.Checkout("develop");
+            fixture.Repository.Reset(ResetMode.Hard, "HEAD~1");
+            fixture.Repository.Checkout("pull/2/merge");
+            // If we delete the branch, it is effectively the same as remote PR
+            fixture.Repository.Branches.Remove("feature/Foo");
+
+            fixture.DumpGraph();
+            fixture.AssertFullSemver("0.2.0-PullRequest.1+3");
+        }
+    }
 }

--- a/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -22,7 +22,30 @@ public class PullRequestScenarios
             fixture.Repository.Checkout("pull/2/merge");
 
             fixture.DumpGraph();
-            fixture.AssertFullSemver("0.1.0-PullRequest.1");
+            fixture.AssertFullSemver("0.1.1-PullRequest.1+2");
+        }
+    }
+
+    [Test]
+    public void CanCalculatePullRequestChangesInheritingConfig()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            fixture.Repository.MakeATaggedCommit("0.1.0");
+            fixture.Repository.CreateBranch("develop").Checkout();
+            fixture.Repository.MakeACommit();
+            fixture.Repository.CreateBranch("feature/Foo").Checkout();
+            fixture.Repository.MakeACommit();
+
+            fixture.Repository.Checkout("develop");
+            fixture.Repository.MergeNoFF("feature/Foo");
+            fixture.Repository.CreateBranch("pull/2/merge").Checkout();
+            fixture.Repository.Checkout("develop");
+            fixture.Repository.Reset(ResetMode.Hard, "HEAD~1");
+            fixture.Repository.Checkout("pull/2/merge");
+
+            fixture.DumpGraph();
+            fixture.AssertFullSemver("0.2.0-PullRequest.1+3");
         }
     }
 }

--- a/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -1,0 +1,28 @@
+﻿using GitVersion;
+using LibGit2Sharp;
+using NUnit.Framework;
+
+[TestFixture]
+public class PullRequestScenarios
+{
+    [Test]
+    public void CanCalculatePullRequestChanges()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            fixture.Repository.MakeATaggedCommit("0.1.0");
+            fixture.Repository.CreateBranch("feature/Foo").Checkout();
+            fixture.Repository.MakeACommit();
+
+            fixture.Repository.Checkout("master");
+            fixture.Repository.MergeNoFF("feature/Foo");
+            fixture.Repository.CreateBranch("pull/2/merge").Checkout();
+            fixture.Repository.Checkout("master");
+            fixture.Repository.Reset(ResetMode.Hard, "HEAD~1");
+            fixture.Repository.Checkout("pull/2/merge");
+
+            fixture.DumpGraph();
+            fixture.AssertFullSemver("0.1.0-PullRequest.1");
+        }
+    }
+}

--- a/GitVersionCore.Tests/Mocks/MockBranch.cs
+++ b/GitVersionCore.Tests/Mocks/MockBranch.cs
@@ -31,6 +31,16 @@ public class MockBranch : Branch, ICollection<Commit>
         get { return canonicalName; }
     }
 
+    public override int GetHashCode()
+    {
+        return name.GetHashCode();
+    }
+
+    public override bool Equals(object obj)
+    {
+        return ReferenceEquals(this, obj);
+    }
+
     public IEnumerator<Commit> GetEnumerator()
     {
         return commits.GetEnumerator();

--- a/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/BaseVersionCalculatorTests.cs
@@ -64,7 +64,7 @@
 
             public override BaseVersion GetVersion(GitVersionContext context)
             {
-                return new BaseVersion(false, true, new SemanticVersion(1), when);
+                return new BaseVersion("Source 1", false, true, new SemanticVersion(1), when, null);
             }
         }
 
@@ -79,7 +79,7 @@
 
             public override BaseVersion GetVersion(GitVersionContext context)
             {
-                return new BaseVersion(true, true, new SemanticVersion(2), when);
+                return new BaseVersion("Source 2", true, true, new SemanticVersion(2), when, null);
             }
         }
     }

--- a/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -10,8 +10,10 @@
     public class MergeMessageBaseVersionStrategyTests
     {
         [Test]
-        public void ShouldAllowIncrementOfVersion()
+        public void ShouldNotAllowIncrementOfVersion()
         {
+            // When a branch is merged in you want to start building stable packages of that version
+            // So we shouldn't bump the version
             var context = new GitVersionContextBuilder().WithRepository(new MockRepository
             {
                 Head = new MockBranch("master") { new MockCommit
@@ -24,7 +26,7 @@
 
             var baseVersion = sut.GetVersion(context);
 
-            baseVersion.ShouldIncrement.ShouldBe(true);
+            baseVersion.ShouldIncrement.ShouldBe(false);
         }
 
         [TestCase("Merge branch 'hotfix-0.1.5'", false, null)]

--- a/GitVersionCore.Tests/VersionCalculation/TestBaseVersionCalculator.cs
+++ b/GitVersionCore.Tests/VersionCalculation/TestBaseVersionCalculator.cs
@@ -22,7 +22,7 @@ namespace GitVersionCore.Tests.VersionCalculation
 
         public BaseVersion GetBaseVersion(GitVersionContext context)
         {
-            return new BaseVersion(shouldIncrement, shouldUpdateTag, semanticVersion, source);
+            return new BaseVersion("Test source", shouldIncrement, shouldUpdateTag, semanticVersion, source, null);
         }
     }
 }

--- a/GitVersionCore/Configuration/Config.cs
+++ b/GitVersionCore/Configuration/Config.cs
@@ -13,6 +13,12 @@
             AssemblyVersioningScheme = AssemblyVersioningScheme.MajorMinorPatch;
             TagPrefix = "[vV]";
             VersioningMode = GitVersion.VersioningMode.ContinuousDelivery;
+
+            Branches["master"] = new BranchConfig
+            {
+                Tag = string.Empty,
+                Increment = IncrementStrategy.Patch,
+            };
             Branches["release[/-]"] = new BranchConfig { Tag = "beta" };
             Branches["feature[/-]"] = new BranchConfig
             {
@@ -25,6 +31,11 @@
                 Tag = "unstable",
                 Increment = IncrementStrategy.Minor,
                 VersioningMode = GitVersion.VersioningMode.ContinuousDeployment
+            };
+            Branches[@"(pull|pull\-requests|pr)[/-]"] = new BranchConfig
+            {
+                Tag = "PullRequest",
+                Increment = IncrementStrategy.Inherit
             };
         }
 

--- a/GitVersionCore/GitHubFlow/LastTaggedReleaseFinder.cs
+++ b/GitVersionCore/GitHubFlow/LastTaggedReleaseFinder.cs
@@ -19,7 +19,7 @@ namespace GitVersion
                 SemanticVersion version;
                 if (SemanticVersion.TryParse(t.Name, context.Configuration.GitTagPrefix, out version))
                 {
-                    return new VersionTaggedCommit((Commit)t.Target, version);
+                    return new VersionTaggedCommit((Commit)t.Target, version, t.Name);
                 }
                 return null;
             })

--- a/GitVersionCore/GitHubFlow/VersionTaggedCommit.cs
+++ b/GitVersionCore/GitHubFlow/VersionTaggedCommit.cs
@@ -4,11 +4,13 @@
 
     public class VersionTaggedCommit
     {
+        public string Tag;
         public Commit Commit;
         public SemanticVersion SemVer;
 
-        public VersionTaggedCommit(Commit commit, SemanticVersion semVer)
+        public VersionTaggedCommit(Commit commit, SemanticVersion semVer, string tag)
         {
+            Tag = tag;
             Commit = commit;
             SemVer = semVer;
         }

--- a/GitVersionCore/GitVersionContext.cs
+++ b/GitVersionCore/GitVersionContext.cs
@@ -127,11 +127,19 @@
             if (parentCount == 2)
             {
                 var parents = CurrentCommit.Parents.ToArray();
-                var branch = Repository.Branches.SingleOrDefault(b => b.Tip == parents[1]);
+                var branch = Repository.Branches.SingleOrDefault(b => b.Tip == parents[1]) ;
                 if (branch != null)
                 {
-                    excludedBranches = new[] { currentBranch, branch };
+                    excludedBranches = new[]
+                    {
+                        currentBranch,
+                        branch
+                    };
                     currentBranch = branch;
+                }
+                else
+                {
+                    currentBranch = Repository.Branches.SingleOrDefault(b => b.Tip == parents[0]) ?? currentBranch;
                 }
             }
 

--- a/GitVersionCore/GitVersionContext.cs
+++ b/GitVersionCore/GitVersionContext.cs
@@ -127,7 +127,7 @@
             if (parentCount == 2)
             {
                 var parents = CurrentCommit.Parents.ToArray();
-                var branch = Repository.Branches.SingleOrDefault(b => b.Tip == parents[1]) ;
+                var branch = Repository.Branches.SingleOrDefault(b => !b.IsRemote && b.Tip == parents[1]) ;
                 if (branch != null)
                 {
                     excludedBranches = new[]
@@ -139,7 +139,7 @@
                 }
                 else
                 {
-                    currentBranch = Repository.Branches.SingleOrDefault(b => b.Tip == parents[0]) ?? currentBranch;
+                    currentBranch = Repository.Branches.SingleOrDefault(b => !b.IsRemote && b.Tip == parents[0]) ?? currentBranch;
                 }
             }
 

--- a/GitVersionCore/GitVersionContext.cs
+++ b/GitVersionCore/GitVersionContext.cs
@@ -83,8 +83,10 @@
         {
             var currentBranchConfig = GetBranchConfiguration(CurrentBranch);
 
-            var versioningMode = currentBranchConfig.Value.VersioningMode ?? configuration.VersioningMode ?? VersioningMode.ContinuousDelivery;
-            var tag = currentBranchConfig.Value.Tag;
+            // Versioning mode drills down, if top level is specified then it takes priority
+            var versioningMode = configuration.VersioningMode ?? currentBranchConfig.Value.VersioningMode ?? VersioningMode.ContinuousDelivery;
+
+            var tag = currentBranchConfig.Value.Tag ?? "useBranchName";
             var nextVersion = configuration.NextVersion;
             var incrementStrategy = currentBranchConfig.Value.Increment ?? IncrementStrategy.Patch;
             var assemblyVersioningScheme = configuration.AssemblyVersioningScheme;

--- a/GitVersionCore/LibGitExtensions.cs
+++ b/GitVersionCore/LibGitExtensions.cs
@@ -26,7 +26,7 @@ namespace GitVersion
 
         public static Commit FindCommitBranchWasBranchedFrom(this Branch branch, IRepository repository)
         {
-            var tips = repository.Branches.Select(b => b.Tip).Where(c => c.Sha != branch.Tip.Sha).ToList();
+            var tips = repository.Branches.Where(b => b != branch).Select(b => b.Tip).ToList();
             return repository.Commits.FirstOrDefault(c => tips.Contains(c) || c.Parents.Count() > 1) ?? branch.Tip;
         }
 

--- a/GitVersionCore/LibGitExtensions.cs
+++ b/GitVersionCore/LibGitExtensions.cs
@@ -26,7 +26,7 @@ namespace GitVersion
 
         public static Commit FindCommitBranchWasBranchedFrom(this Branch branch, IRepository repository, params Branch[] excludedBranches)
         {
-            var tips = repository.Branches.Except(excludedBranches).Where(b => b != branch).Select(b => b.Tip).ToList();
+            var tips = repository.Branches.Except(excludedBranches).Where(b => b != branch && !b.IsRemote).Select(b => b.Tip).ToList();
             return branch.Commits.FirstOrDefault(c => tips.Contains(c) || c.Parents.Count() > 1) ?? branch.Tip;
         }
 

--- a/GitVersionCore/LibGitExtensions.cs
+++ b/GitVersionCore/LibGitExtensions.cs
@@ -24,10 +24,10 @@ namespace GitVersion
             return repository.Branches.FirstOrDefault(x => x.Name == "origin/" + branchName);
         }
 
-        public static Commit FindCommitBranchWasBranchedFrom(this Branch branch, IRepository repository)
+        public static Commit FindCommitBranchWasBranchedFrom(this Branch branch, IRepository repository, params Branch[] excludedBranches)
         {
-            var tips = repository.Branches.Where(b => b != branch).Select(b => b.Tip).ToList();
-            return repository.Commits.FirstOrDefault(c => tips.Contains(c) || c.Parents.Count() > 1) ?? branch.Tip;
+            var tips = repository.Branches.Except(excludedBranches).Where(b => b != branch).Select(b => b.Tip).ToList();
+            return branch.Commits.FirstOrDefault(c => tips.Contains(c) || c.Parents.Count() > 1) ?? branch.Tip;
         }
 
         public static IEnumerable<Tag> TagsByDate(this IRepository repository, Commit commit)

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculator.cs
@@ -14,18 +14,33 @@
 
         public BaseVersion GetBaseVersion(GitVersionContext context)
         {
-            return strategies
+            Logger.WriteInfo("Base Versions:");
+
+            var baseVersion = strategies
                 .Select(s => s.GetVersion(context))
-                .Where(v => v != null)
+                .Where(v =>
+                {
+                    if (v != null)
+                    {
+                        Logger.WriteInfo(v.ToString());
+                        return true;
+                    }
+
+                    return false;
+                })
                 .Aggregate((v1, v2) =>
                 {
                     if (v1.SemanticVersion > v2.SemanticVersion)
                     {
-                        return new BaseVersion(v1.ShouldIncrement, v1.ShouldUpdateTag, v1.SemanticVersion, v1.BaseVersionSource ?? v2.BaseVersionSource);
+                        return new BaseVersion(v1.Source, v1.ShouldIncrement, v1.ShouldUpdateTag, v1.SemanticVersion, v1.BaseVersionSource ?? v2.BaseVersionSource, v1.BranchNameOverride);
                     }
 
-                    return new BaseVersion(v2.ShouldIncrement, v2.ShouldUpdateTag, v2.SemanticVersion, v2.BaseVersionSource ?? v1.BaseVersionSource);
+                    return new BaseVersion(v2.Source, v2.ShouldIncrement, v2.ShouldUpdateTag, v2.SemanticVersion, v2.BaseVersionSource ?? v1.BaseVersionSource, v2.BranchNameOverride);
                 });
+
+            Logger.WriteInfo(string.Format("Base version used: {0}", baseVersion));
+
+            return baseVersion;
         }
     }
 }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/BaseVersion.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/BaseVersion.cs
@@ -4,13 +4,17 @@
 
     public class BaseVersion
     {
-        public BaseVersion(bool shouldIncrement, bool shouldUpdateTag, SemanticVersion semanticVersion, Commit baseVersionSource)
+        public BaseVersion(string source, bool shouldIncrement, bool shouldUpdateTag, SemanticVersion semanticVersion, Commit baseVersionSource, string branchNameOverride)
         {
+            Source = source;
             ShouldIncrement = shouldIncrement;
             ShouldUpdateTag = shouldUpdateTag;
             SemanticVersion = semanticVersion;
             BaseVersionSource = baseVersionSource;
+            BranchNameOverride = branchNameOverride;
         }
+
+        public string Source { get; private set; }
 
         public bool ShouldIncrement { get; private set; }
 
@@ -19,5 +23,12 @@
         public SemanticVersion SemanticVersion { get; private set; }
 
         public Commit BaseVersionSource { get; private set; }
+
+        public string BranchNameOverride { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("{0}: {1} from commit {2}", Source, SemanticVersion.ToString("f"), BaseVersionSource == null ? "External Source" : BaseVersionSource.Sha);
+        }
     }
 }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/ConfigNextVersionBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/ConfigNextVersionBaseVersionStrategy.cs
@@ -6,7 +6,8 @@
         {
             if (string.IsNullOrEmpty(context.Configuration.NextVersion))
                 return null;
-            return new BaseVersion(false, true, SemanticVersion.Parse(context.Configuration.NextVersion, context.Configuration.GitTagPrefix), null);
+            var semanticVersion = SemanticVersion.Parse(context.Configuration.NextVersion, context.Configuration.GitTagPrefix);
+            return new BaseVersion("NextVersion in GitVersionConfig.yaml", false, true, semanticVersion, null, null);
         }
     }
 }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/LastTagBaseVersionStrategy.cs
@@ -8,7 +8,7 @@
             if (new LastTaggedReleaseFinder(context).GetVersion(out version))
             {
                 var shouldUpdateVersion = version.Commit.Sha != context.CurrentCommit.Sha;
-                return new BaseVersion(shouldUpdateVersion, shouldUpdateVersion, version.SemVer, version.Commit);
+                return new BaseVersion(string.Format("Git tag '{0}'", version.Tag), shouldUpdateVersion, shouldUpdateVersion, version.SemVer, version.Commit, null);
             }
 
             return null;

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -16,7 +16,7 @@
                     if (MergeMessageParser.TryParse(c, context.Configuration, out semanticVersion))
                         return new[]
                         {
-                            new BaseVersion(true, true, semanticVersion, c)
+                            new BaseVersion(string.Format("Merge message '{0}'", c.Message.Trim()), false, true, semanticVersion, c, null)
                         };
                     return Enumerable.Empty<BaseVersion>();
                 })

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/VersionInBranchBaseVersionStrategy.cs
@@ -1,7 +1,6 @@
 ﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
 {
     using System;
-    using System.Linq;
 
     public class VersionInBranchBaseVersionStrategy : BaseVersionStrategy
     {
@@ -11,8 +10,8 @@
             if (versionInBranch != null)
             {
                 var commitBranchWasBranchedFrom = context.CurrentBranch.FindCommitBranchWasBranchedFrom(context.Repository);
-                var baseVersionSource = context.CurrentBranch.Commits.First(c => c.Sha != commitBranchWasBranchedFrom.Sha);
-                return new BaseVersion(false, true, versionInBranch.Item2, baseVersionSource);
+                var branchNameOverride = context.CurrentBranch.Name.RegexReplace("[-/]" + versionInBranch.Item1, string.Empty);
+                return new BaseVersion("Version in branch name", false, true, versionInBranch.Item2, commitBranchWasBranchedFrom, branchNameOverride);
             }
 
             return null;

--- a/GitVersionCore/VersionCalculation/FallbackBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/FallbackBaseVersionStrategy.cs
@@ -7,7 +7,7 @@
     {
         public override BaseVersion GetVersion(GitVersionContext context)
         {
-            return new BaseVersion(false, true, new SemanticVersion(minor: 1), context.CurrentBranch.Commits.Last());
+            return new BaseVersion("Fallback base version", false, true, new SemanticVersion(minor: 1), context.CurrentBranch.Commits.Last(), null);
         }
     }
 }

--- a/GitVersionCore/VersionCalculation/MetaDataCalculator.cs
+++ b/GitVersionCore/VersionCalculation/MetaDataCalculator.cs
@@ -14,7 +14,8 @@
                 SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Time
             };
 
-            var commitsSinceTag = context.Repository.Commits.QueryBy(qf).Count();
+            var commitLog = context.Repository.Commits.QueryBy(qf);
+            var commitsSinceTag = commitLog.Count();
 
             return new SemanticVersionBuildMetaData(
                 commitsSinceTag,

--- a/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/NewNextVersionCalculator.cs
@@ -26,12 +26,17 @@
             var baseVersion = baseVersionFinder.GetBaseVersion(context);
 
             if (baseVersion.ShouldIncrement) IncrementVersion(context, baseVersion);
+            else Logger.WriteInfo("Skipping version increment");
 
             if (baseVersion.ShouldUpdateTag && !baseVersion.SemanticVersion.PreReleaseTag.HasTag() && !string.IsNullOrEmpty(context.Configuration.Tag))
             {
                 var tagToUse = context.Configuration.Tag;
                 if (tagToUse == "useBranchName")
-                    tagToUse = context.CurrentBranch.Name.RegexReplace(context.Configuration.BranchPrefixToTrim, string.Empty, RegexOptions.IgnoreCase);
+                {
+                    Logger.WriteInfo("Using branch name to calculate version tag");
+                    var name = baseVersion.BranchNameOverride ?? context.CurrentBranch.Name;
+                    tagToUse = name.RegexReplace(context.Configuration.BranchPrefixToTrim, string.Empty, RegexOptions.IgnoreCase);
+                }
                 baseVersion.SemanticVersion.PreReleaseTag = new SemanticVersionPreReleaseTag(tagToUse, 1);
             }
 
@@ -47,15 +52,19 @@
                 switch (context.Configuration.Increment)
                 {
                     case IncrementStrategy.None:
+                        Logger.WriteInfo("Skipping version increment");
                         break;
                     case IncrementStrategy.Major:
+                        Logger.WriteInfo("Incrementing Major Version");
                         baseVersion.SemanticVersion.Major++;
                         break;
                     case IncrementStrategy.Minor:
                         baseVersion.SemanticVersion.Minor++;
+                        Logger.WriteInfo("Incrementing Minor Version");
                         break;
                     case IncrementStrategy.Patch:
                         baseVersion.SemanticVersion.Patch++;
+                        Logger.WriteInfo("Incrementing Patch Version");
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
Taking a run at fixing a bunch of the failing tests. All of these tests are mainly failing because of commit counting strategies.

I have simplified this a great deal (in my mind). GitVersion now uses this basic rule:

`Count commits from the source of the base version`, if a base version doesn't have a source (say NextVersion from Config) it will use the source from the next base version.

For example, if the base version comes from a tag then it will be counted from that tag. If it is from a version in a branch name then it will be number of commits since that branch was created. If it comes a merge message it will count from when that merge was done.

The current commit counting confuses me. Would love a decent review of the commit counts in this @andreasohlund @SimonCropp @gep13 @nulltoken if possible :)