### PR TITLE
Fixes #375 - Made known merge branch version number extraction case insensitive

### DIFF
--- a/GitVersionCore.Tests/IntegrationTests/GitFlow/ReleaseBranchTests.cs
+++ b/GitVersionCore.Tests/IntegrationTests/GitFlow/ReleaseBranchTests.cs
@@ -53,16 +53,25 @@ public class GitFlowReleaseBranchTests
     [Test]
     public void WhenReleaseBranchIsMergedIntoMasterVersionIsTakenWithIt()
     {
+        DoReleaseBranchIsMergedIntoMasterVersion("release-2.0.0");
+    }
+    [Test]
+    public void WhenReleaseBranchWithUpperCaseIsMergedIntoMasterVersionIsTakenWithIt()
+    {
+        DoReleaseBranchIsMergedIntoMasterVersion("Release-2.0.0");
+    }
+    static void DoReleaseBranchIsMergedIntoMasterVersion(string releaseBranchName)
+    {
         using (var fixture = new EmptyRepositoryFixture(new Config()))
         {
             fixture.Repository.MakeATaggedCommit("1.0.3");
             fixture.Repository.CreateBranch("develop");
             fixture.Repository.MakeCommits(1);
-            fixture.Repository.CreateBranch("release-2.0.0");
-            fixture.Repository.Checkout("release-2.0.0");
+            fixture.Repository.CreateBranch(releaseBranchName);
+            fixture.Repository.Checkout(releaseBranchName);
             fixture.Repository.MakeCommits(4);
             fixture.Repository.Checkout("master");
-            fixture.Repository.MergeNoFF("release-2.0.0", Constants.SignatureNow());
+            fixture.Repository.MergeNoFF(releaseBranchName, Constants.SignatureNow());
 
             // TODO For GitHubFlow this is 2.0.0+6, why is it different
             fixture.AssertFullSemver("2.0.0");

--- a/GitVersionCore/MergeMessageParser.cs
+++ b/GitVersionCore/MergeMessageParser.cs
@@ -27,30 +27,20 @@ namespace GitVersion
 
             var message = mergeCommit.Message.TrimToFirstLine();
 
+            var knownMergePrefixes = new[]
+            { "Merge branch 'hotfix-","Merge branch 'hotfix/","Merge branch 'release-","Merge branch 'release/"};
 
-            if (message.StartsWith("Merge branch 'hotfix-"))
+            foreach (var prefix in knownMergePrefixes)
             {
-                var suffix = message.Replace("Merge branch 'hotfix-", "");
+
+                if (message.StartsWith(prefix))
+            {
+                    var suffix = message.Substring(prefix.Length);
                 return suffix.TryGetPrefix(out versionPart, "'");
             }
 
-            if (message.StartsWith("Merge branch 'hotfix/"))
-            {
-                var suffix = message.Replace("Merge branch 'hotfix/", "");
-                return suffix.TryGetPrefix(out versionPart, "'");
             }
 
-            if (message.StartsWith("Merge branch 'release-"))
-            {
-                var suffix = message.Replace("Merge branch 'release-", "");
-                return suffix.TryGetPrefix(out versionPart, "'");
-            }
-
-            if (message.StartsWith("Merge branch 'release/"))
-            {
-                var suffix = message.Replace("Merge branch 'release/", "");
-                return suffix.TryGetPrefix(out versionPart, "'");
-            }
 
             if (message.StartsWith("Merge branch '"))
             {


### PR DESCRIPTION
Fixes #375 - Made known merge branch version number extraction case insensitive for branch prefix.