### PR TITLE
Fixes #389

### DIFF
--- a/GitVersionCore/GitVersionCore.csproj
+++ b/GitVersionCore/GitVersionCore.csproj
@@ -90,6 +90,7 @@
     <Compile Include="VersionCalculation\BaseVersionCalculator.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\BaseVersion.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\ConfigNextVersionBaseVersionStrategy.cs" />
+    <Compile Include="VersionCalculation\BaseVersionCalculators\GitFlowDevelopBranchBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\HighestTagBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\MergeMessageBaseVersionStrategy.cs" />
     <Compile Include="VersionCalculation\BaseVersionCalculators\VersionInBranchBaseVersionStrategy.cs" />

--- a/GitVersionCore/LibGitExtensions.cs
+++ b/GitVersionCore/LibGitExtensions.cs
@@ -69,6 +69,30 @@ namespace GitVersion
             }
         }
 
+        public static bool IsDirectMergeFromCommit(this Tag tag, Commit commit)
+        {
+            var targetCommit = tag.Target as Commit;
+            if (targetCommit != null)
+            {
+                var parents = targetCommit.Parents;
+                if (parents != null)
+                {
+                    foreach (var parent in parents)
+                    {
+                        if (parent != null)
+                        {
+                            if (string.Equals(parent.Id.Sha, commit.Id.Sha, StringComparison.OrdinalIgnoreCase))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
         public static GitObject PeeledTarget(this Tag tag)
         {
             var target = tag.Target;

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/GitFlowDevelopBranchBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/GitFlowDevelopBranchBaseVersionStrategy.cs
@@ -1,0 +1,20 @@
+﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
+{
+    using LibGit2Sharp;
+
+    public class GitFlowDevelopBranchBaseVersionStrategy : HighestTagBaseVersionStrategy
+    {
+        protected override bool IsValidTag(string branchName, Tag tag, Commit commit)
+        {
+            if (!string.IsNullOrWhiteSpace(branchName))
+            {
+                if (branchName.ToLower().EndsWith("/develop"))
+                {
+                    return tag.IsDirectMergeFromCommit(commit);
+                }
+            }
+
+            return base.IsValidTag(branchName, tag, commit);
+        }
+    }
+}

--- a/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
+++ b/GitVersionCore/VersionCalculation/NextVersionCalculator.cs
@@ -17,10 +17,11 @@
             baseVersionFinder = baseVersionCalculator ??
                 new BaseVersionCalculator(
                     new FallbackBaseVersionStrategy(),
-                new ConfigNextVersionBaseVersionStrategy(),
-                highestTagBaseVersionStrategy,
-                new MergeMessageBaseVersionStrategy(),
-                new VersionInBranchBaseVersionStrategy());
+                    new ConfigNextVersionBaseVersionStrategy(),
+                    highestTagBaseVersionStrategy,
+                    new GitFlowDevelopBranchBaseVersionStrategy(),
+                    new MergeMessageBaseVersionStrategy(),
+                    new VersionInBranchBaseVersionStrategy());
         }
 
         public SemanticVersion FindVersion(GitVersionContext context)


### PR DESCRIPTION
Supports release tags coming from develop branch when no commits are made back to develop.