### PR TITLE
[SPIKE] A more strict approach for finding versions in commit messages

### DIFF
--- a/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -67,6 +67,25 @@
             AssertMergeMessage(message + "\n ", expectedVersion, parents);
         }
 
+        [TestCase(@"Merge pull request #1 in FOO/bar from feature/ISSUE-1 to develop
+
+* commit '38560a7eed06e8d3f3f1aaf091befcdf8bf50fea':
+  Updated jQuery to v2.1.3")]
+        [TestCase(@"Merge pull request #45 in BRIKKS/brikks from feature/NOX-68 to develop
+
+* commit '38560a7eed06e8d3f3f1aaf091befcdf8bf50fea':
+  Another commit message
+  Commit message including a IP-number https://10.50.1.1
+  A commit message")]
+        [TestCase(@"Merge branch 'release/Sprint_2.0_Holdings_Computed_Balances'")]
+        public void MergeMessagesThatsNotRelatedToGitVersion(string commitMessage)
+        {
+
+            var parents = GetParents(true);
+
+            AssertMergeMessage(commitMessage, null, parents);
+        } 
+
         static void AssertMergeMessage(string message, string expectedVersion, List<Commit> parents)
         {
             var commit = new MockCommit

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -1,7 +1,9 @@
 ﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Text.RegularExpressions;
     using LibGit2Sharp;
 
     public class MergeMessageBaseVersionStrategy : BaseVersionStrategy
@@ -42,39 +44,16 @@
                 return null;
             }
 
-            return mergeCommit
-                .Message.Split('/', '-', '\'', '"', ' ')
+            var possibleVersions = Regex.Matches(mergeCommit.Message, @"^.*?(-|/|'|Finish )(?<PossibleVersions>\d+\.\d+\.\d+)")
+                .Cast<Match>()
+                .Select(m => m.Groups["PossibleVersions"].Value);
+
+            return possibleVersions
                 .Select(part =>
                 {
                     SemanticVersion v;
                     return SemanticVersion.TryParse(part, configuration.GitTagPrefix, out v) ? v : null;
-                }).FirstOrDefault(v => v != null)
-                ;
-
-        }
-
-        static bool TryGetPrefix(string target, out string result, string splitter)
-        {
-            var indexOf = target.IndexOf(splitter, StringComparison.Ordinal);
-            if (indexOf == -1)
-            {
-                result = null;
-                return false;
-            }
-            result = target.Substring(0, indexOf);
-            return true;
-        }
-
-        static bool TryGetSuffix(string target, out string result, string splitter)
-        {
-            var indexOf = target.IndexOf(splitter, StringComparison.Ordinal);
-            if (indexOf == -1)
-            {
-                result = null;
-                return false;
-            }
-            result = target.Substring(indexOf + 1, target.Length - indexOf - 1);
-            return true;
+                }).FirstOrDefault(v => v != null);
         }
     }
 }

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -1,7 +1,5 @@
 ﻿namespace GitVersion.VersionCalculation.BaseVersionCalculators
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Text.RegularExpressions;
     using LibGit2Sharp;


### PR DESCRIPTION
It's hard to satisfy the tests without making the assumption that the relevant version is located at the first line. I don't the like the implementation but I think the added tests is correct?
 
References #385