### PR TITLE
Check for null when looking for a git directory and show an appropriate ...

### DIFF
--- a/GitVersionTask.Tests/GitVersionTask.Tests.csproj
+++ b/GitVersionTask.Tests/GitVersionTask.Tests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Helpers\Lg2sHelperBase.cs" />
     <Compile Include="UpdateAssemblyInfoTests.cs" />
     <Compile Include="ModuleInitializer.cs" />
+    <Compile Include="WriteVersionInfoToBuildLogTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/GitVersionTask.Tests/WriteVersionInfoToBuildLogTests.cs
+++ b/GitVersionTask.Tests/WriteVersionInfoToBuildLogTests.cs
@@ -1,0 +1,22 @@
+﻿
+namespace GitVersionTask.Tests
+{
+    using System.IO;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class WriteVersionInfoToBuildLogTests
+    {
+        [Test]
+        public void UsingInvalidGitDirectory_ThrowsDirectoryNotFoundException()
+        {
+            var task = new WriteVersionInfoToBuildLog
+            {
+                BuildEngine = new MockBuildEngine(),
+                SolutionDirectory = Path.GetTempPath()
+            };
+
+            Assert.That(task.InnerExecute, Throws.InstanceOf<DirectoryNotFoundException>());
+        }
+    }
+}

--- a/GitVersionTask/WriteVersionInfoToBuildLog.cs
+++ b/GitVersionTask/WriteVersionInfoToBuildLog.cs
@@ -1,11 +1,12 @@
 ﻿namespace GitVersionTask
 {
-    using System;
-    using System.Collections.Generic;
     using GitVersion;
     using GitVersion.Helpers;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using Logger = GitVersion.Logger;
 
     public class WriteVersionInfoToBuildLog : Task
@@ -51,6 +52,10 @@
         {
             Tuple<CachedVersion, GitVersionContext> result;
             var gitDirectory = GitDirFinder.TreeWalkForGitDir(SolutionDirectory);
+
+            if (gitDirectory == null)
+                throw new DirectoryNotFoundException(string.Format("Unable to locate a git repository in \"{0}\". Make sure that the solution is located in a git controlled folder. If you are using continous integration make sure that the sources are checked out on the build agent.", SolutionDirectory));
+
             var configuration = ConfigurationProvider.Provide(gitDirectory, fileSystem);
             if (!VersionAndBranchFinder.TryGetVersion(SolutionDirectory, out result, configuration))
             {
@@ -66,8 +71,8 @@
             var versioningMode = config.VersioningMode;
 
             var variablesFor = VariableProvider.GetVariablesFor(
-                cachedVersion.SemanticVersion, assemblyVersioningScheme, versioningMode, 
-                config.ContinuousDeploymentFallbackTag, 
+                cachedVersion.SemanticVersion, assemblyVersioningScheme, versioningMode,
+                config.ContinuousDeploymentFallbackTag,
                 gitVersionContext.IsCurrentCommitTagged);
             WriteIntegrationParameters(cachedVersion, BuildServerList.GetApplicableBuildServers(authentication), variablesFor);
         }


### PR DESCRIPTION
...error. Fixes issue #406.

By fixing I mean it throws an exception describing the issue rather than propagating a null further.