### PR TITLE
Added support for -nofetch command line argument and 'NoFetch' MSBuild T...

### DIFF
--- a/GitVersionCore.Tests/BuildServers/BuildServerBaseTests.cs
+++ b/GitVersionCore.Tests/BuildServers/BuildServerBaseTests.cs
@@ -35,7 +35,7 @@ public class BuildServerBaseTests
             throw new NotImplementedException();
         }
 
-        public override void PerformPreProcessingSteps(string gitDirectory)
+        public override void PerformPreProcessingSteps(string gitDirectory, bool noFetch)
         {
             throw new NotImplementedException();
         }

--- a/GitVersionCore/BuildServers/AppVeyor.cs
+++ b/GitVersionCore/BuildServers/AppVeyor.cs
@@ -25,10 +25,7 @@
                 throw new WarningException("Failed to find .git directory on agent.");
             }
 
-            if (!noFetch)
-            {
-                GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
-            }
+            GitHelper.NormalizeGitDirectory(gitDirectory, authentication, noFetch);
         }
 
         public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)

--- a/GitVersionCore/BuildServers/AppVeyor.cs
+++ b/GitVersionCore/BuildServers/AppVeyor.cs
@@ -18,14 +18,17 @@
             return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPVEYOR"));
         }
 
-        public override void PerformPreProcessingSteps(string gitDirectory)
+        public override void PerformPreProcessingSteps(string gitDirectory, bool noFetch)
         {
             if (string.IsNullOrEmpty(gitDirectory))
             {
                 throw new WarningException("Failed to find .git directory on agent.");
             }
 
-            GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+            if (!noFetch)
+            {
+                GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+            }
         }
 
         public override string GenerateSetVersionMessage(string versionToUseForBuildNumber)

--- a/GitVersionCore/BuildServers/BuildServerBase.cs
+++ b/GitVersionCore/BuildServers/BuildServerBase.cs
@@ -5,7 +5,7 @@
     public abstract class BuildServerBase : IBuildServer
     {
         public abstract bool CanApplyToCurrentContext();
-        public abstract void PerformPreProcessingSteps(string gitDirectory);
+        public abstract void PerformPreProcessingSteps(string gitDirectory, bool noFetch);
         public abstract string GenerateSetVersionMessage(string versionToUseForBuildNumber);
         public abstract string[] GenerateSetParameterMessage(string name, string value);
 

--- a/GitVersionCore/BuildServers/ContinuaCi.cs
+++ b/GitVersionCore/BuildServers/ContinuaCi.cs
@@ -28,14 +28,17 @@
             return false;
         }
 
-        public override void PerformPreProcessingSteps(string gitDirectory)
+        public override void PerformPreProcessingSteps(string gitDirectory, bool noFetch)
         {
             if (string.IsNullOrEmpty(gitDirectory))
             {
                 throw new WarningException("Failed to find .git directory on agent");
             }
 
-            GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+            if (!noFetch)
+            {
+                GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+            }
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)

--- a/GitVersionCore/BuildServers/ContinuaCi.cs
+++ b/GitVersionCore/BuildServers/ContinuaCi.cs
@@ -35,10 +35,7 @@
                 throw new WarningException("Failed to find .git directory on agent");
             }
 
-            if (!noFetch)
-            {
-                GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
-            }
+            GitHelper.NormalizeGitDirectory(gitDirectory, authentication, noFetch);
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)

--- a/GitVersionCore/BuildServers/GitHelper.cs
+++ b/GitVersionCore/BuildServers/GitHelper.cs
@@ -9,8 +9,11 @@ namespace GitVersion
     {
         const string MergeMessageRegexPattern = "refs/heads/(pr|pull(-requests)?/(?<issuenumber>[0-9]*)/(merge|head))";
 
-        public static void NormalizeGitDirectory(string gitDirectory, Authentication authentication)
+        public static void NormalizeGitDirectory(string gitDirectory, Authentication authentication, bool noFetch)
         {
+            //If noFetch is enabled, then GitVersion will assume that the git repository is normalized before execution, so that fetching from remotes is not required.
+            if (noFetch) return;
+
             using (var repo = new Repository(gitDirectory))
             {
                 var remote = EnsureOnlyOneRemoteIsDefined(repo);

--- a/GitVersionCore/BuildServers/IBuildServer.cs
+++ b/GitVersionCore/BuildServers/IBuildServer.cs
@@ -5,7 +5,7 @@
     public interface IBuildServer
     {
         bool CanApplyToCurrentContext();
-        void PerformPreProcessingSteps(string gitDirectory);
+        void PerformPreProcessingSteps(string gitDirectory, bool noFetch);
         string GenerateSetVersionMessage(string versionToUseForBuildNumber);
         string[] GenerateSetParameterMessage(string name, string value);
 

--- a/GitVersionCore/BuildServers/MyGet.cs
+++ b/GitVersionCore/BuildServers/MyGet.cs
@@ -27,10 +27,7 @@
                 throw new WarningException("Failed to find .git directory on agent.");
             }
 
-            if (!noFetch)
-            {
-                GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
-            }
+            GitHelper.NormalizeGitDirectory(gitDirectory, authentication, noFetch);
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)

--- a/GitVersionCore/BuildServers/MyGet.cs
+++ b/GitVersionCore/BuildServers/MyGet.cs
@@ -20,14 +20,17 @@
                 && buildRunner.Equals("MyGet", StringComparison.InvariantCultureIgnoreCase);
         }
 
-        public override void PerformPreProcessingSteps(string gitDirectory)
+        public override void PerformPreProcessingSteps(string gitDirectory, bool noFetch)
         {
             if (string.IsNullOrEmpty(gitDirectory))
             {
                 throw new WarningException("Failed to find .git directory on agent.");
             }
 
-            GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+            if (!noFetch)
+            {
+                GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+            }
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)

--- a/GitVersionCore/BuildServers/TeamCity.cs
+++ b/GitVersionCore/BuildServers/TeamCity.cs
@@ -16,14 +16,17 @@
             return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_VERSION"));
         }
 
-        public override void PerformPreProcessingSteps(string gitDirectory)
+        public override void PerformPreProcessingSteps(string gitDirectory, bool noFetch)
         {
             if (string.IsNullOrEmpty(gitDirectory))
             {
                 throw new WarningException("Failed to find .git directory on agent. Please make sure agent checkout mode is enabled for you VCS roots - http://confluence.jetbrains.com/display/TCD8/VCS+Checkout+Mode");
             }
 
-            GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+            if (!noFetch)
+            {
+                GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+            }
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)

--- a/GitVersionCore/BuildServers/TeamCity.cs
+++ b/GitVersionCore/BuildServers/TeamCity.cs
@@ -23,10 +23,7 @@
                 throw new WarningException("Failed to find .git directory on agent. Please make sure agent checkout mode is enabled for you VCS roots - http://confluence.jetbrains.com/display/TCD8/VCS+Checkout+Mode");
             }
 
-            if (!noFetch)
-            {
-                GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
-            }
+            GitHelper.NormalizeGitDirectory(gitDirectory, authentication, noFetch);
         }
 
         public override string[] GenerateSetParameterMessage(string name, string value)

--- a/GitVersionExe.Tests/ArgumentParserTests.cs
+++ b/GitVersionExe.Tests/ArgumentParserTests.cs
@@ -218,4 +218,20 @@ public class ArgumentParserTests
         var arguments = ArgumentParser.ParseArguments("-nofetch");
         arguments.NoFetch = true;
     }
+
+    [Test]
+    public void other_arguments_can_be_parsed_before_nofetch()
+    {
+        var arguments = ArgumentParser.ParseArguments("targetpath -nofetch ");
+        arguments.TargetPath = "targetpath";
+        arguments.NoFetch = true;
+    }
+
+    [Test]
+    public void other_arguments_can_be_parsed_after_nofetch()
+    {
+        var arguments = ArgumentParser.ParseArguments("-nofetch -proj foo.sln");
+        arguments.NoFetch = true;
+        arguments.Proj = "foo.sln";
+    }
 }

--- a/GitVersionExe.Tests/ArgumentParserTests.cs
+++ b/GitVersionExe.Tests/ArgumentParserTests.cs
@@ -211,4 +211,11 @@ public class ArgumentParserTests
         var arguments = ArgumentParser.ParseArguments("-l console -proj foo.sln");
         arguments.LogFilePath.ShouldBe("console");
     }
+
+    [Test]
+    public void nofetch_true_when_defined()
+    {
+        var arguments = ArgumentParser.ParseArguments("-nofetch");
+        arguments.NoFetch = true;
+    }
 }

--- a/GitVersionExe/ArgumentParser.cs
+++ b/GitVersionExe/ArgumentParser.cs
@@ -2,6 +2,7 @@ namespace GitVersion
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Specialized;
     using System.Linq;
     using System.Reflection;
 
@@ -66,11 +67,23 @@ namespace GitVersion
                 arguments.TargetPath = firstArgument;
                 namedArguments = commandLineArguments.Skip(1).ToList();
             }
+            
+            var args = CollectSwitchesAndValuesFromArguments(namedArguments);
 
-            for (var index = 0; index < namedArguments.Count; index = index + 2)
+            foreach (var name in args.AllKeys)
             {
-                var name = namedArguments[index];
-                var value = namedArguments.Count > index + 1 ? namedArguments[index + 1] : null;
+                var values = args.GetValues(name);
+                
+                string value = null;
+                
+                if (values != null)
+                {
+                    //Currently, no arguments use more than one value, so having multiple values is an input error.
+                    //In the future, this exception can be removed to support multiple values for a switch.
+                    if (values.Length > 1) throw new WarningException(string.Format("Could not parse command line parameter '{0}'.", values[1]));
+                    
+                    value = values.FirstOrDefault();
+                }                
 
                 if (IsSwitch("l", name))
                 {
@@ -155,8 +168,7 @@ namespace GitVersion
                     }
                     else
                     {
-                        arguments.UpdateAssemblyInfo = true;
-                        index--;
+                        arguments.UpdateAssemblyInfo = true;                        
                     }
                     continue;
                 }
@@ -184,8 +196,7 @@ namespace GitVersion
                     }
                     else
                     {
-                        arguments.ShowConfig = true;
-                        index--;
+                        arguments.ShowConfig = true;                        
                     }
                     continue;
                 }
@@ -214,9 +225,41 @@ namespace GitVersion
             return arguments;
         }
 
+        static NameValueCollection CollectSwitchesAndValuesFromArguments(List<string> namedArguments)
+        {
+            var args = new NameValueCollection();
+
+            string currentKey = null;
+            for (var index = 0; index < namedArguments.Count; index = index + 1)
+            {
+                var arg = namedArguments[index];
+                //If this is a switch, create new name/value entry for it, with a null value.
+                if (IsSwitchArgument(arg))
+                {
+                    currentKey = arg;
+                    args.Add(currentKey, null);
+                }
+                    //If this is a value (not a switch)
+                else
+                {
+                    //And if the current switch does not have a value yet, set it's value to this argument.
+                    if (String.IsNullOrEmpty(args[currentKey]))
+                    {
+                        args[currentKey] = arg;
+                    }
+                        //Otherwise add the value under the same switch.
+                    else
+                    {
+                        args.Add(currentKey, arg);
+                    }
+                }
+            }
+            return args;
+        }
+
         static bool IsSwitchArgument(string value)
         {
-            return value != null && (value.StartsWith("-") || value.StartsWith("/"));
+            return value != null && (value.StartsWith("-") || value.StartsWith("/")) && !value.StartsWith("/p:"); //Exclude msbuild parameters, which should be parsed as values, not switch names.
         }
 
         static bool IsSwitch(string switchName, string value)

--- a/GitVersionExe/ArgumentParser.cs
+++ b/GitVersionExe/ArgumentParser.cs
@@ -5,8 +5,9 @@ namespace GitVersion
     using System.Collections.Specialized;
     using System.Linq;
     using System.Reflection;
+    using System.Text.RegularExpressions;
 
- 
+
     public class ArgumentParser
     {
         static ArgumentParser()
@@ -259,7 +260,8 @@ namespace GitVersion
 
         static bool IsSwitchArgument(string value)
         {
-            return value != null && (value.StartsWith("-") || value.StartsWith("/")) && !value.StartsWith("/p:"); //Exclude msbuild parameters, which should be parsed as values, not switch names.
+            return value != null && (value.StartsWith("-") || value.StartsWith("/")) 
+                && !Regex.Match(value, @"/\w+:").Success; //Exclude msbuild & project parameters in form /blah:, which should be parsed as values, not switch names.
         }
 
         static bool IsSwitch(string switchName, string value)

--- a/GitVersionExe/ArgumentParser.cs
+++ b/GitVersionExe/ArgumentParser.cs
@@ -202,6 +202,12 @@ namespace GitVersion
                     continue;
                 }
 
+                if (IsSwitch("nofetch", name))
+                {
+                    arguments.NoFetch = true;
+                    continue;
+                }
+
                 throw new WarningException(string.Format("Could not parse command line parameter '{0}'.", name));
             }
 

--- a/GitVersionExe/Arguments.cs
+++ b/GitVersionExe/Arguments.cs
@@ -33,5 +33,6 @@ namespace GitVersion
         public string UpdateAssemblyInfoFileName;
 
         public bool ShowConfig;
+        public bool NoFetch { get; set; }
     }
 }

--- a/GitVersionExe/GitPreparer.cs
+++ b/GitVersionExe/GitPreparer.cs
@@ -67,7 +67,7 @@
                 });
 
             // Normalize (download branches) before using the branch
-            GitHelper.NormalizeGitDirectory(gitDirectory, arguments.Authentication);
+            GitHelper.NormalizeGitDirectory(gitDirectory, arguments.Authentication, arguments.NoFetch);
 
             using (var repository = new Repository(gitDirectory))
             {

--- a/GitVersionExe/Program.cs
+++ b/GitVersionExe/Program.cs
@@ -88,7 +88,7 @@ namespace GitVersion
 
                 foreach (var buildServer in applicableBuildServers)
                 {
-                    buildServer.PerformPreProcessingSteps(gitDirectory);
+                    buildServer.PerformPreProcessingSteps(gitDirectory, arguments.NoFetch);
                 }
                 VersionVariables variables;
                 var versionFinder = new GitVersionFinder();

--- a/GitVersionTask.Tests/GitHelperTests.cs
+++ b/GitVersionTask.Tests/GitHelperTests.cs
@@ -13,7 +13,7 @@ public class GitHelperTests : Lg2sHelperBase
         var gitDirectory = FakeTeamCityFetchAndCheckout(ASBMTestRepoWorkingDirPath, "refs/heads/master");
 
         var authentication = new Authentication();
-        GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+        GitHelper.NormalizeGitDirectory(gitDirectory, authentication, false);
 
         using (var repository = new Repository(gitDirectory))
         {
@@ -31,7 +31,7 @@ public class GitHelperTests : Lg2sHelperBase
         var gitDirectory = FakeTeamCityFetchAndCheckout(repoPath, "refs/pull/1735/merge");
 
         var authentication = new Authentication();
-        GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+        GitHelper.NormalizeGitDirectory(gitDirectory, authentication, false);
 
         using (var repository = new Repository(gitDirectory))
         {
@@ -46,7 +46,7 @@ public class GitHelperTests : Lg2sHelperBase
         var gitDirectory = FakeTeamCityFetchAndCheckout(ASBMTestRepoWorkingDirPath, "refs/heads/develop");
 
         var authentication = new Authentication();
-        GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+        GitHelper.NormalizeGitDirectory(gitDirectory, authentication, false);
 
         using (var repository = new Repository(gitDirectory))
         {
@@ -61,7 +61,7 @@ public class GitHelperTests : Lg2sHelperBase
         var gitDirectory = FakeTeamCityFetchAndCheckout(ASBMTestRepoWorkingDirPath, "refs/heads/feature/one");
 
         var authentication = new Authentication();
-        GitHelper.NormalizeGitDirectory(gitDirectory, authentication);
+        GitHelper.NormalizeGitDirectory(gitDirectory, authentication, false);
 
         using (var repository = new Repository(gitDirectory))
         {

--- a/GitVersionTask.Tests/VersionAndBranchFinderTests.cs
+++ b/GitVersionTask.Tests/VersionAndBranchFinderTests.cs
@@ -20,7 +20,7 @@ public class VersionAndBranchFinderTests: Lg2sHelperBase
         }
 
         Tuple<CachedVersion, GitVersionContext> versionAndBranch;
-        VersionAndBranchFinder.TryGetVersion(ASBMTestRepoWorkingDirPath, out versionAndBranch, new Config());
+        VersionAndBranchFinder.TryGetVersion(ASBMTestRepoWorkingDirPath, out versionAndBranch, new Config(), false);
         Assert.IsNotNull(versionAndBranch);
     }
 }

--- a/GitVersionTask/AssemblyInfoBuilder/UpdateAssemblyInfo.cs
+++ b/GitVersionTask/AssemblyInfoBuilder/UpdateAssemblyInfo.cs
@@ -25,6 +25,8 @@
         [Output]
         public string AssemblyInfoTempFilePath { get; set; }
 
+        public bool NoFetch { get; set; }
+
         TaskLogger logger;
         IFileSystem fileSystem;
 
@@ -73,7 +75,7 @@
             var configuration = ConfigurationProvider.Provide(gitDirectory, fileSystem);
 
             Tuple<CachedVersion, GitVersionContext> semanticVersion;
-            if (!VersionAndBranchFinder.TryGetVersion(SolutionDirectory, out semanticVersion, configuration))
+            if (!VersionAndBranchFinder.TryGetVersion(SolutionDirectory, out semanticVersion, configuration, NoFetch))
             {
                 return;
             }

--- a/GitVersionTask/GetVersion.cs
+++ b/GitVersionTask/GetVersion.cs
@@ -12,6 +12,8 @@
         [Required]
         public string SolutionDirectory { get; set; }
 
+        public bool NoFetch { get; set; }
+
         [Output]
         public string Major { get; set; }
 
@@ -85,7 +87,7 @@
                 var gitDirectory = GitDirFinder.TreeWalkForGitDir(SolutionDirectory);
                 var configuration = ConfigurationProvider.Provide(gitDirectory, fileSystem);
 
-                if (VersionAndBranchFinder.TryGetVersion(SolutionDirectory, out versionAndBranch, configuration))
+                if (VersionAndBranchFinder.TryGetVersion(SolutionDirectory, out versionAndBranch, configuration, NoFetch))
                 {
                     var thisType = typeof(GetVersion);
                     var cachedVersion = versionAndBranch.Item1;

--- a/GitVersionTask/VersionAndBranchFinder.cs
+++ b/GitVersionTask/VersionAndBranchFinder.cs
@@ -5,7 +5,7 @@ using GitVersion;
 public static class VersionAndBranchFinder
 {
     static List<string> processedDirectories = new List<string>(); 
-    public static bool TryGetVersion(string directory, out Tuple<CachedVersion, GitVersionContext> versionAndBranch, Config configuration)
+    public static bool TryGetVersion(string directory, out Tuple<CachedVersion, GitVersionContext> versionAndBranch, Config configuration, bool noFetch)
     {
         var gitDirectory = GitDirFinder.TreeWalkForGitDir(directory);
 
@@ -28,7 +28,7 @@ public static class VersionAndBranchFinder
             foreach (var buildServer in BuildServerList.GetApplicableBuildServers(authentication))
             {
                 Logger.WriteInfo(string.Format("Executing PerformPreProcessingSteps for '{0}'.", buildServer.GetType().Name));
-                buildServer.PerformPreProcessingSteps(gitDirectory);
+                buildServer.PerformPreProcessingSteps(gitDirectory, noFetch);
             }
         }
         versionAndBranch = VersionCache.GetVersion(gitDirectory, configuration);

--- a/GitVersionTask/WriteVersionInfoToBuildLog.cs
+++ b/GitVersionTask/WriteVersionInfoToBuildLog.cs
@@ -13,6 +13,8 @@
         [Required]
         public string SolutionDirectory { get; set; }
 
+        public bool NoFetch { get; set; }
+
         TaskLogger logger;
         IFileSystem fileSystem;
 
@@ -52,7 +54,7 @@
             Tuple<CachedVersion, GitVersionContext> result;
             var gitDirectory = GitDirFinder.TreeWalkForGitDir(SolutionDirectory);
             var configuration = ConfigurationProvider.Provide(gitDirectory, fileSystem);
-            if (!VersionAndBranchFinder.TryGetVersion(SolutionDirectory, out result, configuration))
+            if (!VersionAndBranchFinder.TryGetVersion(SolutionDirectory, out result, configuration, NoFetch))
             {
                 return;
             }


### PR DESCRIPTION
...ask parameter, to suppress fetching from remotes during execution.

Up for review and discussion. I had no problem feeding in the noFetch argument, but I couldn't find an obvious way to test whether or not GitVersion was trying to fetch from a remote or not given the current test fixtures available.  Any pointers?