### PR TITLE
Fix bug on PR when target has two possibilities

### DIFF
--- a/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/PullRequestScenarios.cs
@@ -74,6 +74,24 @@ public class PullRequestScenarios
     }
 
     [Test]
+    public void CanCalculatePullRequestChangesWhenThereAreMultipleMergeCandidates()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            fixture.Repository.MakeATaggedCommit("0.1.0");
+            fixture.Repository.CreateBranch("develop").Checkout();
+            fixture.Repository.MakeACommit();
+            fixture.Repository.CreateBranch("copyOfDevelop").Checkout();
+            fixture.Repository.CreateBranch("feature/Foo").Checkout();
+            fixture.Repository.MakeACommit();
+
+            fixture.Repository.CreatePullRequest("feature/Foo", "develop");
+
+            fixture.AssertFullSemver("0.2.0-PullRequest.2+3");
+        }
+    }
+
+    [Test]
     public void CalculatesCorrectVersionAfterReleaseBranchMergedToMaster()
     {
         using (var fixture = new EmptyRepositoryFixture(new Config()))

--- a/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/GitVersionCore/BranchConfigurationCalculator.cs
@@ -57,7 +57,15 @@ namespace GitVersion
                 }
                 else
                 {
-                    currentBranch = repository.Branches.SingleOrDefault(b => !b.IsRemote && b.Tip == parents[0]) ?? currentBranch;
+                    var possibleTargetBranches = repository.Branches.Where(b => !b.IsRemote && b.Tip == parents[0]).ToList();
+                    if (possibleTargetBranches.Count() > 1)
+                    {
+                        currentBranch = possibleTargetBranches.FirstOrDefault(b => b.Name == "master") ?? possibleTargetBranches.First();
+                    }
+                    else
+                    {
+                        currentBranch = possibleTargetBranches.FirstOrDefault() ?? currentBranch;
+                    }
                 }
 
                 Logger.WriteInfo("HEAD is merge commit, this is likely a pull request using " + currentBranch.Name + " as base");


### PR DESCRIPTION
This PR fixes a bug on pull-request builds when there are two possibilities which branch the pull-reuqest targets.

This should escpecialy fix the build issues happening currently on TeamCity because the repo has a master branch and a release/3.0.0 branch, both pointing to the same commit.