### PR TITLE
Fixes null ref exception when there is a remote 'develop' branch, but no...

### DIFF
--- a/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/GitVersionCore/BranchConfigurationCalculator.cs
@@ -117,7 +117,7 @@ namespace GitVersion
             else
                 errorMessage = "Failed to inherit Increment branch configuration, ended up with: " + string.Join(", ", possibleParents.Select(p => p.Name));
 
-            var hasDevelop = repository.FindBranch("develop") != null;
+            var hasDevelop = repository.Branches["develop"] != null;
             var branchName = hasDevelop ? "develop" : "master";
 
             Logger.WriteWarning(errorMessage + Environment.NewLine + Environment.NewLine + "Falling back to " + branchName + " branch config");


### PR DESCRIPTION
... local develop branch. Fixes #409