### PR TITLE
This changes AssemblyVersioningScheme.MajorMinorPatchMetadata to Assembl...

### DIFF
--- a/GitVersionCore/AssemblyVersioningScheme.cs
+++ b/GitVersionCore/AssemblyVersioningScheme.cs
@@ -2,7 +2,7 @@
 {
     public enum AssemblyVersioningScheme
     {
-        MajorMinorPatchMetadata,
+        MajorMinorPatchTag,
         MajorMinorPatch,
         MajorMinor,
         Major

--- a/GitVersionCore/AssemblyVersionsGenerator.cs
+++ b/GitVersionCore/AssemblyVersionsGenerator.cs
@@ -16,8 +16,8 @@
                     return string.Format("{0}.{1}.0.0", sv.Major, sv.Minor);
                 case AssemblyVersioningScheme.MajorMinorPatch:
                     return string.Format("{0}.{1}.{2}.0", sv.Major, sv.Minor, sv.Patch);
-                case AssemblyVersioningScheme.MajorMinorPatchMetadata:
-                    return string.Format("{0}.{1}.{2}.{3}", sv.Major, sv.Minor, sv.Patch, sv.BuildMetaData.CommitsSinceTag ?? 0);
+                case AssemblyVersioningScheme.MajorMinorPatchTag:
+                    return string.Format("{0}.{1}.{2}.{3}", sv.Major, sv.Minor, sv.Patch, sv.PreReleaseTag.Number ?? 0);
                 default:
                     throw new ArgumentException(string.Format("Unexpected value ({0}).", scheme), "scheme");
             }

--- a/GitVersionCore/Configuration/ConfigSerialiser.cs
+++ b/GitVersionCore/Configuration/ConfigSerialiser.cs
@@ -25,7 +25,7 @@
 
         public static void WriteSample(TextWriter writer)
         {
-            writer.WriteLine("# assembly-versioning-scheme: MajorMinorPatchMetadata | MajorMinorPatch | MajorMinor | Major");
+            writer.WriteLine("# assembly-versioning-scheme: MajorMinorPatchTag | MajorMinorPatch | MajorMinor | Major");
             writer.WriteLine("# tag-prefix: '[vV|version-] # regex to match git tag prefix");
             writer.WriteLine("# next-version: 1.0.0");
             writer.WriteLine("# mode: ContinuousDelivery | ContinuousDeployment");

--- a/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
+++ b/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_Major.approved.txt
@@ -4,7 +4,7 @@ using System.Reflection;
 
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.3.4.0")]
-[assembly: AssemblyInformationalVersion("2.3.4+5.Branch.master.Sha.commitSha")]
+[assembly: AssemblyInformationalVersion("2.3.4-beta.5+6.Branch.master.Sha.commitSha")]
 [assembly: ReleaseDate("2014-03-06")]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
@@ -24,21 +24,21 @@ static class GitVersionInformation
     public static string Major = "2";
     public static string Minor = "3";
     public static string Patch = "4";
-    public static string PreReleaseTag = "";
-    public static string PreReleaseTagWithDash = "";
-    public static string BuildMetaData = "5";
-    public static string FullBuildMetaData = "5.Branch.master.Sha.commitSha";
+    public static string PreReleaseTag = "beta.5";
+    public static string PreReleaseTagWithDash = "-beta.5";
+    public static string BuildMetaData = "6";
+    public static string FullBuildMetaData = "6.Branch.master.Sha.commitSha";
     public static string MajorMinorPatch = "2.3.4";
-    public static string SemVer = "2.3.4";
-    public static string LegacySemVer = "2.3.4";
-    public static string LegacySemVerPadded = "2.3.4";
+    public static string SemVer = "2.3.4-beta.5";
+    public static string LegacySemVer = "2.3.4-beta5";
+    public static string LegacySemVerPadded = "2.3.4-beta0005";
     public static string AssemblySemVer = "2.0.0.0";
-    public static string FullSemVer = "2.3.4+5";
-    public static string InformationalVersion = "2.3.4+5.Branch.master.Sha.commitSha";
+    public static string FullSemVer = "2.3.4-beta.5+6";
+    public static string InformationalVersion = "2.3.4-beta.5+6.Branch.master.Sha.commitSha";
     public static string BranchName = "master";
     public static string Sha = "commitSha";
-    public static string NuGetVersionV2 = "2.3.4";
-    public static string NuGetVersion = "2.3.4";
+    public static string NuGetVersionV2 = "2.3.4-beta0005";
+    public static string NuGetVersion = "2.3.4-beta0005";
 
 }
 

--- a/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
+++ b/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinor.approved.txt
@@ -4,7 +4,7 @@ using System.Reflection;
 
 [assembly: AssemblyVersion("2.3.0.0")]
 [assembly: AssemblyFileVersion("2.3.4.0")]
-[assembly: AssemblyInformationalVersion("2.3.4+5.Branch.master.Sha.commitSha")]
+[assembly: AssemblyInformationalVersion("2.3.4-beta.5+6.Branch.master.Sha.commitSha")]
 [assembly: ReleaseDate("2014-03-06")]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
@@ -24,21 +24,21 @@ static class GitVersionInformation
     public static string Major = "2";
     public static string Minor = "3";
     public static string Patch = "4";
-    public static string PreReleaseTag = "";
-    public static string PreReleaseTagWithDash = "";
-    public static string BuildMetaData = "5";
-    public static string FullBuildMetaData = "5.Branch.master.Sha.commitSha";
+    public static string PreReleaseTag = "beta.5";
+    public static string PreReleaseTagWithDash = "-beta.5";
+    public static string BuildMetaData = "6";
+    public static string FullBuildMetaData = "6.Branch.master.Sha.commitSha";
     public static string MajorMinorPatch = "2.3.4";
-    public static string SemVer = "2.3.4";
-    public static string LegacySemVer = "2.3.4";
-    public static string LegacySemVerPadded = "2.3.4";
+    public static string SemVer = "2.3.4-beta.5";
+    public static string LegacySemVer = "2.3.4-beta5";
+    public static string LegacySemVerPadded = "2.3.4-beta0005";
     public static string AssemblySemVer = "2.3.0.0";
-    public static string FullSemVer = "2.3.4+5";
-    public static string InformationalVersion = "2.3.4+5.Branch.master.Sha.commitSha";
+    public static string FullSemVer = "2.3.4-beta.5+6";
+    public static string InformationalVersion = "2.3.4-beta.5+6.Branch.master.Sha.commitSha";
     public static string BranchName = "master";
     public static string Sha = "commitSha";
-    public static string NuGetVersionV2 = "2.3.4";
-    public static string NuGetVersion = "2.3.4";
+    public static string NuGetVersionV2 = "2.3.4-beta0005";
+    public static string NuGetVersion = "2.3.4-beta0005";
 
 }
 

--- a/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
+++ b/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatch.approved.txt
@@ -4,7 +4,7 @@ using System.Reflection;
 
 [assembly: AssemblyVersion("2.3.4.0")]
 [assembly: AssemblyFileVersion("2.3.4.0")]
-[assembly: AssemblyInformationalVersion("2.3.4+5.Branch.master.Sha.commitSha")]
+[assembly: AssemblyInformationalVersion("2.3.4-beta.5+6.Branch.master.Sha.commitSha")]
 [assembly: ReleaseDate("2014-03-06")]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
@@ -24,21 +24,21 @@ static class GitVersionInformation
     public static string Major = "2";
     public static string Minor = "3";
     public static string Patch = "4";
-    public static string PreReleaseTag = "";
-    public static string PreReleaseTagWithDash = "";
-    public static string BuildMetaData = "5";
-    public static string FullBuildMetaData = "5.Branch.master.Sha.commitSha";
+    public static string PreReleaseTag = "beta.5";
+    public static string PreReleaseTagWithDash = "-beta.5";
+    public static string BuildMetaData = "6";
+    public static string FullBuildMetaData = "6.Branch.master.Sha.commitSha";
     public static string MajorMinorPatch = "2.3.4";
-    public static string SemVer = "2.3.4";
-    public static string LegacySemVer = "2.3.4";
-    public static string LegacySemVerPadded = "2.3.4";
+    public static string SemVer = "2.3.4-beta.5";
+    public static string LegacySemVer = "2.3.4-beta5";
+    public static string LegacySemVerPadded = "2.3.4-beta0005";
     public static string AssemblySemVer = "2.3.4.0";
-    public static string FullSemVer = "2.3.4+5";
-    public static string InformationalVersion = "2.3.4+5.Branch.master.Sha.commitSha";
+    public static string FullSemVer = "2.3.4-beta.5+6";
+    public static string InformationalVersion = "2.3.4-beta.5+6.Branch.master.Sha.commitSha";
     public static string BranchName = "master";
     public static string Sha = "commitSha";
-    public static string NuGetVersionV2 = "2.3.4";
-    public static string NuGetVersion = "2.3.4";
+    public static string NuGetVersionV2 = "2.3.4-beta0005";
+    public static string NuGetVersion = "2.3.4-beta0005";
 
 }
 

--- a/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
+++ b/GitVersionTask.Tests/AssemblyInfoBuilderTests.VerifyAssemblyVersion_MajorMinorPatchTag.approved.txt
@@ -4,7 +4,7 @@ using System.Reflection;
 
 [assembly: AssemblyVersion("2.3.4.5")]
 [assembly: AssemblyFileVersion("2.3.4.0")]
-[assembly: AssemblyInformationalVersion("2.3.4+5.Branch.master.Sha.commitSha")]
+[assembly: AssemblyInformationalVersion("2.3.4-beta.5+6.Branch.master.Sha.commitSha")]
 [assembly: ReleaseDate("2014-03-06")]
 
 [System.Runtime.CompilerServices.CompilerGenerated]
@@ -24,21 +24,21 @@ static class GitVersionInformation
     public static string Major = "2";
     public static string Minor = "3";
     public static string Patch = "4";
-    public static string PreReleaseTag = "";
-    public static string PreReleaseTagWithDash = "";
-    public static string BuildMetaData = "5";
-    public static string FullBuildMetaData = "5.Branch.master.Sha.commitSha";
+    public static string PreReleaseTag = "beta.5";
+    public static string PreReleaseTagWithDash = "-beta.5";
+    public static string BuildMetaData = "6";
+    public static string FullBuildMetaData = "6.Branch.master.Sha.commitSha";
     public static string MajorMinorPatch = "2.3.4";
-    public static string SemVer = "2.3.4";
-    public static string LegacySemVer = "2.3.4";
-    public static string LegacySemVerPadded = "2.3.4";
+    public static string SemVer = "2.3.4-beta.5";
+    public static string LegacySemVer = "2.3.4-beta5";
+    public static string LegacySemVerPadded = "2.3.4-beta0005";
     public static string AssemblySemVer = "2.3.4.5";
-    public static string FullSemVer = "2.3.4+5";
-    public static string InformationalVersion = "2.3.4+5.Branch.master.Sha.commitSha";
+    public static string FullSemVer = "2.3.4-beta.5+6";
+    public static string InformationalVersion = "2.3.4-beta.5+6.Branch.master.Sha.commitSha";
     public static string BranchName = "master";
     public static string Sha = "commitSha";
-    public static string NuGetVersionV2 = "2.3.4";
-    public static string NuGetVersion = "2.3.4";
+    public static string NuGetVersionV2 = "2.3.4-beta0005";
+    public static string NuGetVersion = "2.3.4-beta0005";
 
 }
 

--- a/GitVersionTask.Tests/AssemblyInfoBuilderTests.cs
+++ b/GitVersionTask.Tests/AssemblyInfoBuilderTests.cs
@@ -68,9 +68,9 @@ public class AssemblyInfoBuilderTests
 
     [Test]
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void VerifyAssemblyVersion_MajorMinorPatchMetadata()
+    public void VerifyAssemblyVersion_MajorMinorPatchTag()
     {
-        VerifyAssemblyVersion(AssemblyVersioningScheme.MajorMinorPatchMetadata);
+        VerifyAssemblyVersion(AssemblyVersioningScheme.MajorMinorPatchTag);
     }
 
     static void VerifyAssemblyVersion(AssemblyVersioningScheme avs)
@@ -80,7 +80,8 @@ public class AssemblyInfoBuilderTests
             Major = 2,
             Minor = 3,
             Patch = 4,
-            BuildMetaData = new SemanticVersionBuildMetaData(5,
+            PreReleaseTag = "beta.5",
+            BuildMetaData = new SemanticVersionBuildMetaData(6,
                 "master", "commitSha", DateTimeOffset.Parse("2014-03-06 23:59:59Z")),
         };
         var assemblyInfoBuilder = new AssemblyInfoBuilder


### PR DESCRIPTION
...yVersioningScheme.MajorMinorPatchTag

The issue with metadata is that it is not part of the semantic version at all, so why are we even allowing it to be put into the assembly version. On the other hand in continuous delivery we promote metadata to the tag to allow the version to change every commit. By using the tag, not the metadata we can create meaningful AssemblySemVer values.

Fixes #391