### PR TITLE
Fix for inheriting config where develop branch is named development

### DIFF
--- a/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -1,3 +1,4 @@
+using System;
 using GitVersion;
 using LibGit2Sharp;
 using NUnit.Framework;
@@ -5,6 +6,33 @@ using NUnit.Framework;
 [TestFixture]
 public class FeatureBranchScenarios
 {
+    [Test]
+    public void ShouldInheritIncrementCorrectlyWithMultiplePossibleParentsAndWeirdlyNamedDevelopBranch()
+    {
+        using (var fixture = new EmptyRepositoryFixture(new Config()))
+        {
+            fixture.Repository.MakeATaggedCommit("1.0.0");
+            fixture.Repository.CreateBranch("development");
+            fixture.Repository.Checkout("development");
+
+            //Create an initial feature branch
+            var feature123 = fixture.Repository.CreateBranch("feature/JIRA-123");
+            fixture.Repository.Checkout("feature/JIRA-123");
+            fixture.Repository.MakeCommits(1);
+
+            //Merge it
+            fixture.Repository.Checkout("development");
+            fixture.Repository.Merge(feature123, new Signature("me", "me@me.com", DateTimeOffset.Now));
+
+            //Create a second feature branch
+            fixture.Repository.CreateBranch("feature/JIRA-124");
+            fixture.Repository.Checkout("feature/JIRA-124");
+            fixture.Repository.MakeCommits(1);
+
+            fixture.AssertFullSemver("1.1.0-JIRA-124.1+2");
+        }
+    }
+
     [Test]
     public void ShouldNotUseNumberInFeatureBranchAsPreReleaseNumberOffDevelop()
     {

--- a/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
+++ b/GitVersionCore.Tests/IntegrationTests/FeatureBranchScenarios.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using GitVersion;
 using LibGit2Sharp;
 using NUnit.Framework;
@@ -22,6 +23,36 @@ public class FeatureBranchScenarios
 
             //Merge it
             fixture.Repository.Checkout("development");
+            fixture.Repository.Merge(feature123, new Signature("me", "me@me.com", DateTimeOffset.Now));
+
+            //Create a second feature branch
+            fixture.Repository.CreateBranch("feature/JIRA-124");
+            fixture.Repository.Checkout("feature/JIRA-124");
+            fixture.Repository.MakeCommits(1);
+
+            fixture.AssertFullSemver("1.1.0-JIRA-124.1+2");
+        }
+    }
+    
+    [Test]
+    public void BranchCreatedAfterFastForwardMergeShouldInheritCorrectly()
+    {
+        var config = new Config();
+        config.Branches.Add("unstable", config.Branches["develop"]);
+
+        using (var fixture = new EmptyRepositoryFixture(config))
+        {
+            fixture.Repository.MakeATaggedCommit("1.0.0");
+            fixture.Repository.CreateBranch("unstable");
+            fixture.Repository.Checkout("unstable");
+
+            //Create an initial feature branch
+            var feature123 = fixture.Repository.CreateBranch("feature/JIRA-123");
+            fixture.Repository.Checkout("feature/JIRA-123");
+            fixture.Repository.MakeCommits(1);
+
+            //Merge it
+            fixture.Repository.Checkout("unstable");
             fixture.Repository.Merge(feature123, new Signature("me", "me@me.com", DateTimeOffset.Now));
 
             //Create a second feature branch

--- a/GitVersionCore/BranchConfigurationCalculator.cs
+++ b/GitVersionCore/BranchConfigurationCalculator.cs
@@ -117,8 +117,8 @@ namespace GitVersion
             else
                 errorMessage = "Failed to inherit Increment branch configuration, ended up with: " + string.Join(", ", possibleParents.Select(p => p.Name));
 
-            var hasDevelop = repository.Branches["develop"] != null;
-            var branchName = hasDevelop ? "develop" : "master";
+            var developBranch = repository.Branches.FirstOrDefault(b => Regex.IsMatch(b.Name, "^develop", RegexOptions.IgnoreCase));
+            var branchName = developBranch != null ? developBranch.Name : "master";
 
             Logger.WriteWarning(errorMessage + Environment.NewLine + Environment.NewLine + "Falling back to " + branchName + " branch config");
             var value = GetBranchConfiguration(currentCommit, repository, onlyEvaluateTrackedBranches, config, repository.Branches[branchName]).Value;


### PR DESCRIPTION
Noticed this issue on our build server, the feature branches were incrementing patch and development was incrementing minor.
Occurs when creating a new feature branch having just merged another, which triggers the fallback logic in BranchConfigurationCalculator