### PR TITLE
Fix tracking branches in dynamic repositories

### DIFF
--- a/GitVersionCore/BuildServers/GitHelper.cs
+++ b/GitVersionCore/BuildServers/GitHelper.cs
@@ -185,7 +185,9 @@ namespace GitVersion
 
             foreach (var remoteTrackingReference in repo.Refs.FromGlob(prefix + "*").Where(r => r.CanonicalName != remoteHeadCanonicalName))
             {
-                var localCanonicalName = "refs/heads/" + remoteTrackingReference.CanonicalName.Substring(prefix.Length);
+                var remoteTrackingReferenceName = remoteTrackingReference.CanonicalName;
+                var branchName = remoteTrackingReferenceName.Substring(prefix.Length);
+                var localCanonicalName = "refs/heads/" + branchName;
 
                 if (repo.Refs.Any(x => x.CanonicalName == localCanonicalName))
                 {
@@ -203,6 +205,9 @@ namespace GitVersion
                 {
                     repo.Refs.Add(localCanonicalName, new ObjectId(symbolicReference.ResolveToDirectReference().TargetIdentifier), true);
                 }
+
+                var branch = repo.Branches[branchName];
+                repo.Branches.Update(branch, b => b.TrackedBranch = remoteTrackingReferenceName);
             }
         }
 

--- a/GitVersionExe.Tests/GitPreparerTests.cs
+++ b/GitVersionExe.Tests/GitPreparerTests.cs
@@ -208,5 +208,41 @@ public class GitPreparerTests
         }
     }
 
+    [Test]
+    public void UsingDynamicRepositoryWithFeatureBranchWorks()
+    {
+        var repoName = Guid.NewGuid().ToString();
+        var tempPath = Path.GetTempPath();
+        var tempDir = Path.Combine(tempPath, repoName);
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            using (var mainRepositoryFixture = new EmptyRepositoryFixture(new Config()))
+            {
+                var commitId = mainRepositoryFixture.Repository.MakeACommit().Id.Sha;
+
+                var arguments = new Arguments
+                {
+                    TargetPath = tempDir,
+                    TargetUrl = mainRepositoryFixture.RepositoryPath,
+                    TargetBranch = "feature1",
+                    CommitId = commitId
+                };
+
+                var gitPreparer = new GitPreparer(arguments.TargetUrl, arguments.DynamicRepositoryLocation, arguments.Authentication, arguments.TargetBranch, arguments.NoFetch, arguments.TargetPath);
+                gitPreparer.Initialise(true);
+
+                mainRepositoryFixture.Repository.CreateBranch("feature1").Checkout();
+
+                Assert.DoesNotThrow(() => gitPreparer.Initialise(true));
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
     // TODO test around normalisation
 }


### PR DESCRIPTION
When running GitVersion with a dynamic repository using a new branch it cannot find a remote tracking branch. I dug a bit deeper and found that in `GitHelper.CreateMissingLocalBranchesFromRemoteTrackingOnes` the `remoteTrackingReference` is a `DirectReference`, but I think it should be a `SymbolicReference` for this to work.

I'm not sure how to fix this as I'm not familiar with LibGit2Sharp. Any advice?