### PR TITLE
Filter out merge messages that look like versions but aren't

### DIFF
--- a/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
+++ b/GitVersionCore.Tests/VersionCalculation/Strategies/MergeMessageBaseVersionStrategyTests.cs
@@ -80,6 +80,7 @@
   Commit message including a IP-number https://10.50.1.1
   A commit message")]
         [TestCase(@"Merge branch 'release/Sprint_2.0_Holdings_Computed_Balances'")]
+        [TestCase(@"Merge branch 'feature/fix-for-08.14-push'")]
         public void MergeMessagesThatsNotRelatedToGitVersion(string commitMessage)
         {
 

--- a/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
+++ b/GitVersionCore/VersionCalculation/BaseVersionCalculators/MergeMessageBaseVersionStrategy.cs
@@ -42,7 +42,8 @@
                 return null;
             }
 
-            var possibleVersions = Regex.Matches(mergeCommit.Message, @"^.*?(-|-v|/|/v|'|Finish )(?<PossibleVersions>\d+\.\d+(\.*\d+)*)")
+            //TODO: Make the version prefixes customizable
+            var possibleVersions = Regex.Matches(mergeCommit.Message, @"^.*?(([rR]elease|[hH]otfix|[aA]lpha)-|-v|/|/v|'|Finish )(?<PossibleVersions>\d+\.\d+(\.*\d+)*)")
                 .Cast<Match>()
                 .Select(m => m.Groups["PossibleVersions"].Value);
 


### PR DESCRIPTION
Add more specific regex matching for possible version numbers in merge
messages. Fixes #466

All existing Tests pass and I have added one test case to validate this
change.