### PR TITLE
Use authentication in `GitPreparer.GetRemoteReference`

### DIFF
--- a/GitVersionCore/BuildServers/GitHelper.cs
+++ b/GitVersionCore/BuildServers/GitHelper.cs
@@ -1,5 +1,6 @@
 namespace GitVersion
 {
+    using System;
     using LibGit2Sharp;
     using System.Collections.Generic;
     using System.Linq;
@@ -162,6 +163,20 @@ namespace GitVersion
 
             Logger.WriteInfo(string.Format("Checking local branch '{0}' out.", fakeBranchName));
             repo.Checkout(fakeBranchName);
+        }
+
+        internal static IEnumerable<DirectReference> GetRemoteTipsUsingUsernamePasswordCredentials(Repository repo, string repoUrl, string username, string password)
+        {
+            // This is a work-around as long as https://github.com/libgit2/libgit2sharp/issues/1099 is not fixed
+            var remote = repo.Network.Remotes.Add(Guid.NewGuid().ToString(), repoUrl);
+            try
+            {
+                return GetRemoteTipsUsingUsernamePasswordCredentials(repo, remote, username, password);
+            }
+            finally
+            {
+                repo.Network.Remotes.Remove(remote.Name);
+            }
         }
 
         static IEnumerable<DirectReference> GetRemoteTipsUsingUsernamePasswordCredentials(Repository repo, Remote remote, string username, string password)

--- a/GitVersionCore/GitPreparer.cs
+++ b/GitVersionCore/GitPreparer.cs
@@ -172,7 +172,7 @@ namespace GitVersion
 
                 if (newHead == null)
                 {
-                    var remoteReference = GetRemoteReference(repository, targetBranch, repositoryUrl);
+                    var remoteReference = GetRemoteReference(repository, targetBranch, repositoryUrl, authentication);
                     if (remoteReference != null)
                     {
                         repository.Network.Fetch(repositoryUrl, new[]
@@ -202,11 +202,11 @@ namespace GitVersion
             return repository.Refs.FirstOrDefault(localRef => string.Equals(localRef.CanonicalName, targetBranchName));
         }
 
-        private static DirectReference GetRemoteReference(Repository repository, string branchName, string repositoryUrl)
+        private static DirectReference GetRemoteReference(Repository repository, string branchName, string repositoryUrl, Authentication authentication)
         {
             var targetBranchName = branchName.GetCanonicalBranchName();
-            var remoteReferences = repository.Network.ListReferences(repositoryUrl);
 
+            var remoteReferences = GitHelper.GetRemoteTipsUsingUsernamePasswordCredentials(repository, repositoryUrl, authentication.Username, authentication.Password);
             return remoteReferences.FirstOrDefault(remoteRef => string.Equals(remoteRef.CanonicalName, targetBranchName));
         }
     }


### PR DESCRIPTION
You already had a helper for this (`GitHelper.GetRemoteTipsUsingUsernamePasswordCredentials`), but it was internal. I made it public.

I saw somewhere else that you used `repository.Network.Remotes.Single()`, which fails when there are multiple remotes, so I'm not sure if it's ok that I also used it.